### PR TITLE
Add a getter for a reference to an element in matrix

### DIFF
--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -420,11 +420,11 @@ namespace alp {
 	namespace internal {
 
 		// Forward declaration
-		template< typename T, typename MatrixType >
-		const T &getReference( const MatrixType &, const size_t, const size_t );
+		template< typename MatrixType >
+		const typename MatrixType::value_type &getReference( const MatrixType &, const size_t, const size_t );
 
-		template< typename T, typename MatrixType >
-		T &getReference( MatrixType &, const size_t, const size_t );
+		template< typename MatrixType >
+		typename MatrixType::value_type &getReference( MatrixType &, const size_t, const size_t );
 
 		/**
 		 * Base Matrix class containing attributes common to all Matrix specialization
@@ -483,8 +483,6 @@ namespace alp {
 					Vector< T, reference >,
 					Vector< T, reference > &
 				>::type container_type;
-
-				friend MatrixBase< self_type >;
 
 				/** A container-type view is characterized by its association with a physical container */
 				container_type container;

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -421,10 +421,10 @@ namespace alp {
 
 		// Forward declaration
 		template< typename MatrixType >
-		const typename MatrixType::value_type &getReference( const MatrixType &, const size_t, const size_t );
+		const typename MatrixType::value_type &access( const MatrixType &, const size_t, const size_t );
 
 		template< typename MatrixType >
-		typename MatrixType::value_type &getReference( MatrixType &, const size_t, const size_t );
+		typename MatrixType::value_type &access( MatrixType &, const size_t, const size_t );
 
 		/**
 		 * Base Matrix class containing attributes common to all Matrix specialization
@@ -441,19 +441,19 @@ namespace alp {
 				}
 
 				template< typename MatrixType >
-				friend const typename MatrixType::value_type &getReference( const MatrixType &A, const size_t i, const size_t j );
+				friend const typename MatrixType::value_type &access( const MatrixType &A, const size_t i, const size_t j );
 
 				template< typename MatrixType >
-				friend typename MatrixType::value_type &getReference( MatrixType &A, const size_t i, const size_t j );
+				friend typename MatrixType::value_type &access( MatrixType &A, const size_t i, const size_t j );
 
 				template< typename T >
-				const T &getReference( const size_t i, const size_t j ) const {
-					return static_cast< const DerivedMatrix & >( *this ).getReference( i, j );
+				const T &access( const size_t i, const size_t j ) const {
+					return static_cast< const DerivedMatrix & >( *this ).access( i, j );
 				}
 
 				template< typename T >
-				T &getReference( const size_t i, const size_t j ) {
-					return static_cast< DerivedMatrix & >( *this ).getReference( i, j );
+				T &access( const size_t i, const size_t j ) {
+					return static_cast< DerivedMatrix & >( *this ).access( i, j );
 				}
 
 		};
@@ -556,11 +556,11 @@ namespace alp {
 				 *
 				 * @return constant reference to the element with coordinates (i, j).
 				 */
-				const T &getReference( const size_t i, const size_t j ) const {
+				const T &access( const size_t i, const size_t j ) const {
 					return container[ amf.map( i, j ) ];
 				}
 
-				T &getReference( const size_t i, const size_t j ) {
+				T &access( const size_t i, const size_t j ) {
 					return container[ amf.map( i, j ) ];
 				}
 
@@ -1523,13 +1523,13 @@ namespace alp {
 		 * \note   This method may be used to access only elements local to the processor.
 		 */
 		template< typename MatrixType >
-		const typename MatrixType::value_type &getReference( const MatrixType &A, const size_t i, const size_t j ) {
-			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template getReference< typename MatrixType::value_type >( i, j );
+		const typename MatrixType::value_type &access( const MatrixType &A, const size_t i, const size_t j ) {
+			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::value_type >( i, j );
 		}
 
 		template< typename MatrixType >
-		typename MatrixType::value_type &getReference( MatrixType &A, const size_t i, const size_t j ) {
-			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template getReference< typename MatrixType::value_type >( i, j );
+		typename MatrixType::value_type &access( MatrixType &A, const size_t i, const size_t j ) {
+			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::value_type >( i, j );
 		}
 
 	} // namespace internal

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -446,13 +446,15 @@ namespace alp {
 				template< typename MatrixType >
 				friend typename MatrixType::access_type access( MatrixType &A, const size_t i, const size_t j );
 
-				template< typename T >
-				const T access( const size_t i, const size_t j ) const {
+				template< typename AccessType >
+				const AccessType access( const size_t i, const size_t j ) const {
+					static_assert( std::is_same< AccessType, typename DerivedMatrix::access_type >::value );
 					return static_cast< const DerivedMatrix & >( *this ).access( i, j );
 				}
 
-				template< typename T >
-				T &access( const size_t i, const size_t j ) {
+				template< typename AccessType >
+				AccessType access( const size_t i, const size_t j ) {
+					static_assert( std::is_same< AccessType, typename DerivedMatrix::access_type >::value );
 					return static_cast< DerivedMatrix & >( *this ).access( i, j );
 				}
 
@@ -1517,8 +1519,10 @@ namespace alp {
 		 * @param[in] i row coordinate of matrix A
 		 * @param[in] j column coordinate of matrix A
 		 *
-		 * @return A constant reference to the element at the position (i, j)
-		 *         of matrix A
+		 * @return For container matrices, returns a constant reference to the
+		 *         element at the position (i, j) of matrix A.
+		 *         For functor view matrices, returns a value corresponding to
+		 *         the position (i, j) of matrix A.
 		 *
 		 * \note   This method may be used to access only elements local to the processor.
 		 */
@@ -1527,6 +1531,7 @@ namespace alp {
 			return static_cast< const MatrixBase< typename MatrixType::base_type > >( A ).template access< const typename MatrixType::access_type >( i, j );
 		}
 
+		/** Non-constant variant. **/
 		template< typename MatrixType >
 		typename MatrixType::access_type access( MatrixType &A, const size_t i, const size_t j ) {
 			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::access_type >( i, j );

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -421,10 +421,10 @@ namespace alp {
 
 		// Forward declaration
 		template< typename MatrixType >
-		const typename MatrixType::access_type access( const MatrixType &, const size_t );
+		const typename MatrixType::access_type access( const MatrixType &, const typename MatrixType::storage_index_type & );
 
 		template< typename MatrixType >
-		typename MatrixType::access_type access( MatrixType &, const size_t );
+		typename MatrixType::access_type access( MatrixType &, const typename MatrixType::storage_index_type & );
 
 		template< typename MatrixType >
 		typename MatrixType::storage_index_type getStorageIndex( const MatrixType &A, const size_t i, const size_t j, const size_t s = 0, const size_t P = 1 );
@@ -444,23 +444,25 @@ namespace alp {
 				}
 
 				template< typename MatrixType >
-				friend const typename MatrixType::access_type access( const MatrixType &A, const size_t storageIndex );
+				friend const typename MatrixType::access_type access( const MatrixType &A, const typename MatrixType::storage_index_type &storageIndex );
 
 				template< typename MatrixType >
-				friend typename MatrixType::access_type access( MatrixType &A, const size_t storageIndex );
+				friend typename MatrixType::access_type access( MatrixType &A, const typename MatrixType::storage_index_type &storageIndex );
 
 				template< typename MatrixType >
 				friend typename MatrixType::storage_index_type getStorageIndex( const MatrixType &A, const size_t i, const size_t j, const size_t s, const size_t P );
 
-				template< typename AccessType >
-				const AccessType access( const size_t storageIndex ) const {
+				template< typename AccessType, typename StorageIndexType >
+				const AccessType access( const StorageIndexType storageIndex ) const {
 					static_assert( std::is_same< AccessType, typename DerivedMatrix::access_type >::value );
+					static_assert( std::is_same< StorageIndexType, typename DerivedMatrix::storage_index_type >::value );
 					return static_cast< const DerivedMatrix & >( *this ).access( storageIndex );
 				}
 
-				template< typename AccessType >
-				AccessType access( const size_t storageIndex ) {
+				template< typename AccessType, typename StorageIndexType >
+				AccessType access( const StorageIndexType &storageIndex ) {
 					static_assert( std::is_same< AccessType, typename DerivedMatrix::access_type >::value );
+					static_assert( std::is_same< StorageIndexType, typename DerivedMatrix::storage_index_type >::value );
 					return static_cast< DerivedMatrix & >( *this ).access( storageIndex );
 				}
 
@@ -572,11 +574,11 @@ namespace alp {
 				 *
 				 * @return const reference or value of the element at given position.
 				 */
-				const access_type access( const size_t storageIndex ) const {
+				const access_type access( const storage_index_type &storageIndex ) const {
 					return container[ storageIndex ];
 				}
 
-				access_type access( const size_t storageIndex ) {
+				access_type access( const storage_index_type &storageIndex ) {
 					return container[ storageIndex ];
 				}
 
@@ -1552,14 +1554,14 @@ namespace alp {
 		 * \note   This method may be used to access only elements local to the processor.
 		 */
 		template< typename MatrixType >
-		const typename MatrixType::access_type access( const MatrixType &A, const size_t storageIndex ) {
-			return static_cast< const MatrixBase< typename MatrixType::base_type > >( A ).template access< const typename MatrixType::access_type >( storageIndex );
+		const typename MatrixType::access_type access( const MatrixType &A, const typename MatrixType::storage_index_type &storageIndex ) {
+			return static_cast< const MatrixBase< typename MatrixType::base_type > >( A ).template access< const typename MatrixType::access_type, typename MatrixType::storage_index_type >( storageIndex );
 		}
 
 		/** Non-constant variant. **/
 		template< typename MatrixType >
-		typename MatrixType::access_type access( MatrixType &A, const size_t storageIndex ) {
-			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::access_type >( storageIndex );
+		typename MatrixType::access_type access( MatrixType &A, const typename MatrixType::storage_index_type &storageIndex ) {
+			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::access_type, typename MatrixType::storage_index_type >( storageIndex );
 		}
 
 		/** Return a storage index in the physical layout.

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -471,6 +471,8 @@ namespace alp {
 				/** Expose static properties */
 
 				typedef T value_type;
+				/** Type returned by access function */
+				typedef T &access_type;
 				typedef ImfR imfr_type;
 				typedef ImfC imfc_type;
 
@@ -610,6 +612,8 @@ namespace alp {
 
 				/** Expose static properties */
 				typedef T value_type;
+				/** Type returned by access function */
+				typedef T access_type;
 
 				typedef ImfR imfr_type;
 				typedef ImfC imfc_type;

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -466,6 +466,11 @@ namespace alp {
 		 */
 		template< typename T, typename ImfR, typename ImfC, typename Smf, bool is_original >
 		class MatrixContainer : public MatrixBase< MatrixContainer< T, ImfR, ImfC, Smf, is_original > > {
+			public:
+
+				/** Expose static properties */
+
+				typedef T value_type;
 
 			protected:
 				typedef MatrixContainer< T, ImfR, ImfC, Smf, is_original > self_type;
@@ -601,6 +606,10 @@ namespace alp {
 		 */
 		template< typename T, typename ImfR, typename ImfC, typename Ret, typename ... Args >
 		class MatrixFunctor : public MatrixBase< MatrixFunctor< T, ImfR, ImfC, Ret, Args... > > {
+			public:
+
+				/** Expose static properties */
+				typedef T value_type;
 
 			protected:
 				ImfR imf_r;
@@ -709,7 +718,6 @@ namespace alp {
 
 		public:
 			/** Exposes the types and the static properties. */
-			typedef T value_type;
 			typedef structures::General structure;
 			typedef ImfR imfr_type;
 			typedef ImfC imfc_type;
@@ -839,7 +847,6 @@ namespace alp {
 
 		public:
 			/** Exposes the types and the static properties. */
-			typedef T value_type;
 			typedef structures::Square structure;
 			typedef ImfR imfr_type;
 			typedef ImfC imfc_type;
@@ -942,7 +949,6 @@ namespace alp {
 
 		public:
 			/** Exposes the element type and the structure. */
-			typedef T value_type;
 			typedef structures::UpperTriangular structure;
 			typedef ImfR imfr_type;
 			typedef ImfC imfc_type;
@@ -1042,7 +1048,6 @@ namespace alp {
 //
 //		public:
 //			/** Exposes the element type and the structure. */
-//			typedef T value_type;
 //			typedef structures::Identity structure;
 //
 //			template < view::Views view_tag, bool d=false >

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -421,10 +421,10 @@ namespace alp {
 
 		// Forward declaration
 		template< typename MatrixType >
-		const typename MatrixType::value_type &access( const MatrixType &, const size_t, const size_t );
+		const typename MatrixType::access_type access( const MatrixType &, const size_t, const size_t );
 
 		template< typename MatrixType >
-		typename MatrixType::value_type &access( MatrixType &, const size_t, const size_t );
+		typename MatrixType::access_type access( MatrixType &, const size_t, const size_t );
 
 		/**
 		 * Base Matrix class containing attributes common to all Matrix specialization
@@ -441,13 +441,13 @@ namespace alp {
 				}
 
 				template< typename MatrixType >
-				friend const typename MatrixType::value_type &access( const MatrixType &A, const size_t i, const size_t j );
+				friend const typename MatrixType::access_type access( const MatrixType &A, const size_t i, const size_t j );
 
 				template< typename MatrixType >
-				friend typename MatrixType::value_type &access( MatrixType &A, const size_t i, const size_t j );
+				friend typename MatrixType::access_type access( MatrixType &A, const size_t i, const size_t j );
 
 				template< typename T >
-				const T &access( const size_t i, const size_t j ) const {
+				const T access( const size_t i, const size_t j ) const {
 					return static_cast< const DerivedMatrix & >( *this ).access( i, j );
 				}
 
@@ -556,11 +556,11 @@ namespace alp {
 				 *
 				 * @return constant reference to the element with coordinates (i, j).
 				 */
-				const T &access( const size_t i, const size_t j ) const {
+				const access_type access( const size_t i, const size_t j ) const {
 					return container[ amf.map( i, j ) ];
 				}
 
-				T &access( const size_t i, const size_t j ) {
+				access_type access( const size_t i, const size_t j ) {
 					return container[ amf.map( i, j ) ];
 				}
 
@@ -625,7 +625,7 @@ namespace alp {
 				typedef std::function< Ret( Args... ) > lambda_function_type;
 				lambda_function_type &lambda;
 
-				T get( const size_t i, const size_t j ) const {
+				access_type access( const size_t i, const size_t j ) const {
 					return lambda( imf_r.map( i ), imf_c.map( j ) );
 				}
 
@@ -1523,13 +1523,13 @@ namespace alp {
 		 * \note   This method may be used to access only elements local to the processor.
 		 */
 		template< typename MatrixType >
-		const typename MatrixType::value_type &access( const MatrixType &A, const size_t i, const size_t j ) {
-			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::value_type >( i, j );
+		const typename MatrixType::access_type access( const MatrixType &A, const size_t i, const size_t j ) {
+			return static_cast< const MatrixBase< typename MatrixType::base_type > >( A ).template access< const typename MatrixType::access_type >( i, j );
 		}
 
 		template< typename MatrixType >
-		typename MatrixType::value_type &access( MatrixType &A, const size_t i, const size_t j ) {
-			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::value_type >( i, j );
+		typename MatrixType::access_type access( MatrixType &A, const size_t i, const size_t j ) {
+			return static_cast< MatrixBase< typename MatrixType::base_type > >( A ).template access< typename MatrixType::access_type >( i, j );
 		}
 
 	} // namespace internal

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -471,6 +471,8 @@ namespace alp {
 				/** Expose static properties */
 
 				typedef T value_type;
+				typedef ImfR imfr_type;
+				typedef ImfC imfc_type;
 
 			protected:
 				typedef MatrixContainer< T, ImfR, ImfC, Smf, is_original > self_type;
@@ -611,6 +613,9 @@ namespace alp {
 				/** Expose static properties */
 				typedef T value_type;
 
+				typedef ImfR imfr_type;
+				typedef ImfC imfc_type;
+
 			protected:
 				ImfR imf_r;
 				ImfC imf_c;
@@ -719,8 +724,6 @@ namespace alp {
 		public:
 			/** Exposes the types and the static properties. */
 			typedef structures::General structure;
-			typedef ImfR imfr_type;
-			typedef ImfC imfc_type;
 			typedef smf::Full_t smf_type;
 			/**
 			 * Indicates if a matrix is an original container.
@@ -848,8 +851,6 @@ namespace alp {
 		public:
 			/** Exposes the types and the static properties. */
 			typedef structures::Square structure;
-			typedef ImfR imfr_type;
-			typedef ImfC imfc_type;
 			typedef smf::Full_t smf_type;
 			static constexpr bool is_original = std::is_same< target_type, void >::value;
 			typedef internal::MatrixContainer< T, ImfR, ImfC, smf::Full_t, is_original > base_type;
@@ -950,8 +951,6 @@ namespace alp {
 		public:
 			/** Exposes the element type and the structure. */
 			typedef structures::UpperTriangular structure;
-			typedef ImfR imfr_type;
-			typedef ImfC imfc_type;
 			typedef smf::Full_t smf_type;
 			static constexpr bool is_original = std::is_same< target_type, void >::value;
 			typedef internal::MatrixContainer< T, ImfR, ImfC, smf::Full_t, is_original > base_type;

--- a/include/alp/smf.hpp
+++ b/include/alp/smf.hpp
@@ -152,12 +152,40 @@ namespace alp {
 
 				AMF( ImfR &&imf_r, ImfC &&imf_c, Smf smf ) : imf_r( imf_r ), imf_c( imf_c ), smf( smf ) {}
 
-				size_t map( const size_t i, const size_t j ) const {
+				/**
+				 * Returns a storage index based on the coordinates in the
+				 * logical iteration space.
+				 *
+				 * @param[in] i  row-coordinate
+				 * @param[in] j  column-coordinate
+				 * @param[in] s  current process ID
+				 * @param[in] P  total number of processes
+				 *
+				 * @return  storage index corresponding to the provided logical
+				 *          coordinates and parameters s and P.
+				 */
+				size_t getStorageIndex( const size_t i, const size_t j, const size_t s, const size_t P ) const {
 #ifdef _DEBUG
-					std::cout << "Calling AMF::map()\n";
+					std::cout << "Calling AMF::getStorageIndex()\n";
 #endif
+					(void)s;
+					(void)P;
 					return smf.f( imf_r.map( i ), imf_c.map( j ) );
 				}
+
+				/**
+				 * Returns coordinates in the logical iteration space based on
+				 * the storage index.
+				 *
+				 * @param[in] storageIndex  storage index in the physical
+				 *                          iteration space
+				 * @param[in] s             current process ID
+				 * @param[in] P             total number of processes
+				 *
+				 * @return  a pair of row- and column-coordinates in the
+				 *          logical iteration space.
+				 */
+				std::pair< size_t, size_t > getCoords( const size_t storageIndex, const size_t s, const size_t P ) const;
 		};
 
 		template< typename Smf >
@@ -194,12 +222,14 @@ namespace alp {
 					imf_r( imf_r ), imf_c( imf_c ), smf( smf ), amf( fusion( imf_r, imf_c, smf ) ) {
 				}
 
-				size_t map( const size_t i, const size_t j ) const {
+				size_t getStorageIndex( const size_t i, const size_t j, const size_t s, const size_t P ) const {
 #ifdef _DEBUG
-					std::cout << "Calling AMF::map()\n";
+					std::cout << "Calling AMF::getStorageIndex()\n";
 #endif
 					// TODO: Maybe these asserts should be pushed to debug mode
 					// for performance reasons.
+					(void)s;
+					(void)P;
 					assert( i < imf_r.n );
 					assert( j < imf_c.n );
 					return amf.f( i, j );

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -200,6 +200,10 @@ add_grb_executables( spy spy.cpp
 	BACKENDS reference reference_omp
 )
 
+add_grb_executables( dense_matrix_access dense_matrix_access.cpp
+	BACKENDS alp_reference
+)
+
 # Temporarily disable until containers rework is completed
 #add_grb_executables( dense_constant_matrices dense_constant_matrices.cpp
 #	BACKENDS alp_reference

--- a/tests/unit/dense_matrix_access.cpp
+++ b/tests/unit/dense_matrix_access.cpp
@@ -1,0 +1,124 @@
+
+/*
+ *   Copyright 2021 Huawei Technologies Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <memory>
+
+#include <alp.hpp>
+
+template< typename MatrixType >
+void setElements( MatrixType &M, const typename MatrixType::value_type value ) {
+	const size_t height = alp::ncols( M );
+	const size_t width = alp::nrows( M );
+	for( size_t r = 0; r < height; ++r ) {
+		for( size_t c = 0; c < width; ++c ) {
+			alp::internal::getReference( M, r, c ) = value;
+		}
+	}
+}
+
+void alp_program( const size_t & n, alp::RC & rc ) {
+
+	const size_t width = 2 * n;
+	const size_t height = n;
+	std::cout << "\tStarting structured matrices test with size ( H x W ): " << height << " x " << width <<  "\n";
+	rc = alp::SUCCESS;
+
+	// create the original matrix
+	alp::Matrix< float, alp::structures::General > M( n, n );
+	// set matrix elements using the internal interface
+	setElements( M, 1 );
+	// create transposed view over M
+	auto Mt = alp::get_view< alp::view::transpose >( M );
+	// create a square view over M and treat it as a matrix view with a square structure
+	const size_t block_size = 4;
+	auto Mview = alp::get_view( M, alp::utils::range( 0, block_size ), alp::utils::range( 0, block_size ) );
+	auto Sq_Mref = alp::get_view< alp::structures::Square > ( Mview );
+
+	// verify that accessing corner elements succeeds
+	// original matrix
+	alp::internal::getReference( M, 0, 0 );
+	alp::internal::getReference( M, height - 1, 0 );
+	alp::internal::getReference( M, 0, width - 1 );
+	alp::internal::getReference( M, height - 1, width - 1 );
+
+	// transposed view
+	alp::internal::getReference( Mt, 0, 0 );
+	alp::internal::getReference( Mt, width - 1, 0 );
+	alp::internal::getReference( Mt, 0, height - 1 );
+	alp::internal::getReference( Mt, width - 1, height - 1 );
+
+	// square block view
+	alp::internal::getReference( Sq_Mref, 0, 0 );
+	alp::internal::getReference( Sq_Mref, block_size - 1, 0 );
+	alp::internal::getReference( Sq_Mref, 0, block_size - 1 );
+	alp::internal::getReference( Sq_Mref, block_size - 1, block_size - 1 );
+
+	rc = alp::SUCCESS;
+}
+
+int main( int argc, char ** argv ) {
+	// defaults
+	bool printUsage = false;
+	size_t in = 5;
+
+	// error checking
+	if( argc > 2 ) {
+		printUsage = true;
+	}
+	if( argc == 2 ) {
+		size_t read;
+		std::istringstream ss( argv[ 1 ] );
+		if( ! ( ss >> read ) ) {
+			std::cerr << "Error parsing first argument\n";
+			printUsage = true;
+		} else if( ! ss.eof() ) {
+			std::cerr << "Error parsing first argument\n";
+			printUsage = true;
+		} else if( read % 2 != 0 ) {
+			std::cerr << "Given value for n is odd\n";
+			printUsage = true;
+		} else {
+			// all OK
+			in = read;
+		}
+	}
+	if( printUsage ) {
+		std::cerr << "Usage: " << argv[ 0 ] << " [n]\n";
+		std::cerr << "  -n (optional, default is 100): an even integer, the "
+					 "test size.\n";
+		return 1;
+	}
+
+	std::cout << "This is functional test " << argv[ 0 ] << "\n";
+	alp::Launcher< alp::AUTOMATIC > launcher;
+	alp::RC out;
+	if( launcher.exec( &alp_program, in, out, true ) != alp::SUCCESS ) {
+		std::cerr << "Launching test FAILED\n";
+		return 255;
+	}
+	if( out != alp::SUCCESS ) {
+		std::cerr << "Test FAILED (" << alp::toString( out ) << ")" << std::endl;
+	} else {
+		std::cout << "Test OK" << std::endl;
+	}
+	return 0;
+}

--- a/tests/unit/dense_matrix_access.cpp
+++ b/tests/unit/dense_matrix_access.cpp
@@ -30,7 +30,7 @@ void setElements( MatrixType &M, const typename MatrixType::value_type value ) {
 	const size_t width = alp::nrows( M );
 	for( size_t r = 0; r < height; ++r ) {
 		for( size_t c = 0; c < width; ++c ) {
-			alp::internal::access( M, r, c ) = value;
+			alp::internal::access( M, alp::internal::getStorageIndex( M, r, c ) ) = value;
 		}
 	}
 }
@@ -55,22 +55,22 @@ void alp_program( const size_t & n, alp::RC & rc ) {
 
 	// verify that accessing corner elements succeeds
 	// original matrix
-	alp::internal::access( M, 0, 0 );
-	alp::internal::access( M, height - 1, 0 );
-	alp::internal::access( M, 0, width - 1 );
-	alp::internal::access( M, height - 1, width - 1 );
+	alp::internal::access( M, alp::internal::getStorageIndex( M, 0, 0 ) );
+	alp::internal::access( M, alp::internal::getStorageIndex( M, height - 1, 0 ) );
+	alp::internal::access( M, alp::internal::getStorageIndex( M, 0, width - 1 ) );
+	alp::internal::access( M, alp::internal::getStorageIndex( M, height - 1, width - 1 ) );
 
 	// transposed view
-	alp::internal::access( Mt, 0, 0 );
-	alp::internal::access( Mt, width - 1, 0 );
-	alp::internal::access( Mt, 0, height - 1 );
-	alp::internal::access( Mt, width - 1, height - 1 );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( M, 0, 0 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( M, width - 1, 0 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( M, 0, height - 1 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( M, width - 1, height - 1 ) );
 
 	// square block view
-	alp::internal::access( Sq_Mref, 0, 0 );
-	alp::internal::access( Sq_Mref, block_size - 1, 0 );
-	alp::internal::access( Sq_Mref, 0, block_size - 1 );
-	alp::internal::access( Sq_Mref, block_size - 1, block_size - 1 );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, 0, 0 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, block_size - 1, 0 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, 0, block_size - 1 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, block_size - 1, block_size - 1 ) );
 
 	rc = alp::SUCCESS;
 }

--- a/tests/unit/dense_matrix_access.cpp
+++ b/tests/unit/dense_matrix_access.cpp
@@ -30,7 +30,7 @@ void setElements( MatrixType &M, const typename MatrixType::value_type value ) {
 	const size_t width = alp::nrows( M );
 	for( size_t r = 0; r < height; ++r ) {
 		for( size_t c = 0; c < width; ++c ) {
-			alp::internal::getReference( M, r, c ) = value;
+			alp::internal::access( M, r, c ) = value;
 		}
 	}
 }
@@ -55,22 +55,22 @@ void alp_program( const size_t & n, alp::RC & rc ) {
 
 	// verify that accessing corner elements succeeds
 	// original matrix
-	alp::internal::getReference( M, 0, 0 );
-	alp::internal::getReference( M, height - 1, 0 );
-	alp::internal::getReference( M, 0, width - 1 );
-	alp::internal::getReference( M, height - 1, width - 1 );
+	alp::internal::access( M, 0, 0 );
+	alp::internal::access( M, height - 1, 0 );
+	alp::internal::access( M, 0, width - 1 );
+	alp::internal::access( M, height - 1, width - 1 );
 
 	// transposed view
-	alp::internal::getReference( Mt, 0, 0 );
-	alp::internal::getReference( Mt, width - 1, 0 );
-	alp::internal::getReference( Mt, 0, height - 1 );
-	alp::internal::getReference( Mt, width - 1, height - 1 );
+	alp::internal::access( Mt, 0, 0 );
+	alp::internal::access( Mt, width - 1, 0 );
+	alp::internal::access( Mt, 0, height - 1 );
+	alp::internal::access( Mt, width - 1, height - 1 );
 
 	// square block view
-	alp::internal::getReference( Sq_Mref, 0, 0 );
-	alp::internal::getReference( Sq_Mref, block_size - 1, 0 );
-	alp::internal::getReference( Sq_Mref, 0, block_size - 1 );
-	alp::internal::getReference( Sq_Mref, block_size - 1, block_size - 1 );
+	alp::internal::access( Sq_Mref, 0, 0 );
+	alp::internal::access( Sq_Mref, block_size - 1, 0 );
+	alp::internal::access( Sq_Mref, 0, block_size - 1 );
+	alp::internal::access( Sq_Mref, block_size - 1, block_size - 1 );
 
 	rc = alp::SUCCESS;
 }

--- a/tests/unit/dense_matrix_access.cpp
+++ b/tests/unit/dense_matrix_access.cpp
@@ -61,16 +61,16 @@ void alp_program( const size_t & n, alp::RC & rc ) {
 	alp::internal::access( M, alp::internal::getStorageIndex( M, height - 1, width - 1 ) );
 
 	// transposed view
-	alp::internal::access( Mt, alp::internal::getStorageIndex( M, 0, 0 ) );
-	alp::internal::access( Mt, alp::internal::getStorageIndex( M, width - 1, 0 ) );
-	alp::internal::access( Mt, alp::internal::getStorageIndex( M, 0, height - 1 ) );
-	alp::internal::access( Mt, alp::internal::getStorageIndex( M, width - 1, height - 1 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( Mt, 0, 0 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( Mt, width - 1, 0 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( Mt, 0, height - 1 ) );
+	alp::internal::access( Mt, alp::internal::getStorageIndex( Mt, width - 1, height - 1 ) );
 
 	// square block view
-	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, 0, 0 ) );
-	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, block_size - 1, 0 ) );
-	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, 0, block_size - 1 ) );
-	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( M, block_size - 1, block_size - 1 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( Sq_Mref, 0, 0 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( Sq_Mref, block_size - 1, 0 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( Sq_Mref, 0, block_size - 1 ) );
+	alp::internal::access( Sq_Mref, alp::internal::getStorageIndex( Sq_Mref, block_size - 1, block_size - 1 ) );
 
 	rc = alp::SUCCESS;
 }


### PR DESCRIPTION
This exposes a const and non-const getter.
Add a unit test for matrix element access.