### PR TITLE
472 grb set does not execute in parallel

### DIFF
--- a/include/graphblas/reference/coordinates.hpp
+++ b/include/graphblas/reference/coordinates.hpp
@@ -378,11 +378,20 @@ namespace grb {
 					// and initialise _assigned (but only if necessary)
 					if( dim > 0 && !arr_initialized ) {
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() * 8 )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, dim );
+#else
+							const size_t start = 0;
+							const size_t end = dim;
 #endif
-						for( size_t i = 0; i < dim; ++i ) {
-							_assigned[ i ] = false;
+							for( size_t i = start; i < end; ++i ) {
+								_assigned[ i ] = false;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					}
 				}
 

--- a/include/graphblas/reference/coordinates.hpp
+++ b/include/graphblas/reference/coordinates.hpp
@@ -378,7 +378,7 @@ namespace grb {
 					// and initialise _assigned (but only if necessary)
 					if( dim > 0 && !arr_initialized ) {
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() * 8 )
 #endif
 						for( size_t i = 0; i < dim; ++i ) {
 							_assigned[ i ] = false;

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -394,7 +394,7 @@ namespace grb {
 		DataType * const raw = internal::getRaw( x );
 		const size_t n = internal::getCoordinates( x ).size();
 
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 		#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
 #endif
 		for( size_t i = 0; i < n; ++ i ) {
@@ -475,7 +475,7 @@ namespace grb {
 		const auto & m_coors = internal::getCoordinates( m );
 		auto m_p = internal::getRaw( m );
 
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 		#pragma omp parallel
 		{
 			auto localUpdate = coors.EMPTY_UPDATE();
@@ -494,7 +494,7 @@ namespace grb {
 			const size_t n = loop_over_vector_length ?
 				coors.size() :
 				m_coors.nonzeroes();
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp for schedule(dynamic,config::CACHE_LINE_SIZE::value()) nowait
 #endif
 			for( size_t k = 0; k < n; ++k ) {
@@ -502,7 +502,7 @@ namespace grb {
 				if( !m_coors.template mask< descr >( index, m_p ) ) {
 					continue;
 				}
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 				if( !coors.asyncAssign( index, localUpdate ) ) {
 					(void)++asyncAssigns;
 				}
@@ -517,7 +517,7 @@ namespace grb {
 					internal::ValueOrIndex< descr, DataType, DataType >::getFromScalar(
 						toCopy, index );
 			}
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			while( !coors.joinUpdate( localUpdate ) ) {}
 		} // end pragma omp parallel
 #endif
@@ -657,7 +657,7 @@ namespace grb {
 		// first copy contents
 		if( src == nullptr && dst == nullptr ) {
 			// then source is a pattern vector, just copy its pattern
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp parallel for schedule( dynamic, config::CACHE_LINE_SIZE::value() )
 #endif
 			for( size_t i = 0; i < nz; ++i ) {
@@ -671,7 +671,7 @@ namespace grb {
 			}
 #endif
 			// otherwise, the regular copy variant:
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
 #endif
 			for( size_t i = 0; i < nz; ++i ) {
@@ -789,7 +789,7 @@ namespace grb {
 			( y_coors.nonzeroes() < m_coors.nonzeroes() );
 		const size_t n = loop_over_y ? y_coors.nonzeroes() : m_coors.nonzeroes();
 
-#ifdef _H_GRB_REFERENCE_OMP_BLAS1
+#ifdef _H_GRB_REFERENCE_OMP_IO
 		// keeps track of updates of the sparsity pattern
 		#pragma omp parallel
 		{
@@ -923,12 +923,12 @@ namespace grb {
 				}
 			}
 
-#ifdef _H_GRB_REFERENCE_OMP_BLAS3
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp parallel
 #endif
 			{
 				size_t range = internal::getCRS( C ).copyFromRange( nz, m );
-#ifdef _H_GRB_REFERENCE_OMP_BLAS3
+#ifdef _H_GRB_REFERENCE_OMP_IO
 				size_t start, end;
 				config::OMP::localRange( start, end, 0, range );
 #else
@@ -945,7 +945,7 @@ namespace grb {
 					);
 				}
 				range = internal::getCCS( C ).copyFromRange( nz, n );
-#ifdef _H_GRB_REFERENCE_OMP_BLAS3
+#ifdef _H_GRB_REFERENCE_OMP_IO
 				config::OMP::localRange( start, end, 0, range );
 #else
 				end = range;

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -672,7 +672,7 @@ namespace grb {
 #endif
 			// otherwise, the regular copy variant:
 #ifdef _H_GRB_REFERENCE_OMP_IO
-			#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+			#pragma omp parallel for schedule( static, ( 4096 + sizeof( OutputType ) - 1 ) / sizeof( OutputType ) )
 #endif
 			for( size_t i = 0; i < nz; ++i ) {
 				const auto index = internal::getCoordinates( x ).asyncCopy(

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -672,16 +672,25 @@ namespace grb {
 #endif
 			// otherwise, the regular copy variant:
 #ifdef _H_GRB_REFERENCE_OMP_IO
-			#pragma omp parallel for schedule( static, ( 4096 + sizeof( OutputType ) - 1 ) / sizeof( OutputType ) )
+			#pragma omp parallel
+			{
+				size_t start, end;
+				config::OMP::localRange( start, end, 0, nz );
+#else
+				const size_t start = 0;
+				const size_t end = nz;
 #endif
-			for( size_t i = 0; i < nz; ++i ) {
-				const auto index = internal::getCoordinates( x ).asyncCopy(
-					internal::getCoordinates( y ), i );
-				if( !out_is_void && !in_is_void ) {
-					dst[ index ] = internal::setIndexOrValue< descr, OutputType >(
-						index, src[ index ] );
+				for( size_t i = start; i < end; ++i ) {
+					const auto index = internal::getCoordinates( x ).asyncCopy(
+						internal::getCoordinates( y ), i );
+					if( !out_is_void && !in_is_void ) {
+						dst[ index ] = internal::setIndexOrValue< descr, OutputType >(
+							index, src[ index ] );
+					}
 				}
+#ifdef _H_GRB_REFERENCE_OMP_IO
 			}
+#endif
 		}
 
 		// set number of nonzeroes


### PR DESCRIPTION
This MR contains the following changes:
- bugfix: an earlier MR moved the `grb::set` functions of the reference and reference_omp backends to `reference/io.cpp`, but did not update the parallelisation guards.
- code improvement: rely on `config::OMP::localRange` instead of parallel-for with a chunked static schedule. In several cases related to calls to `grb::set` and vector construction this leads to significant speedups.

This resolves internal issue 472 and contributes to internal issue 479.

Thanks to Alberto Scolari for contributing!