### PR TITLE
479 openmp chunked static parallel for does not do the intended thing

### DIFF
--- a/include/graphblas/banshee/blas3.hpp
+++ b/include/graphblas/banshee/blas3.hpp
@@ -326,11 +326,18 @@ namespace grb {
 
 	namespace internal {
 
-		template< Descriptor descr = descriptors::no_operation, bool matrix_is_void, typename OutputType, typename InputType1, typename InputType2, typename InputType3, typename Coords >
-		RC matrix_zip_generic( Matrix< OutputType, banshee > & A,
-			const Vector< InputType1, banshee, Coords > & x,
-			const Vector< InputType2, banshee, Coords > & y,
-			const Vector< InputType3, banshee, Coords > & z ) {
+		template<
+			Descriptor descr = descriptors::no_operation,
+			bool matrix_is_void,
+			typename OutputType, typename InputType1, typename InputType2, typename InputType3,
+			typename Coords
+		>
+		RC matrix_zip_generic(
+			Matrix< OutputType, banshee > &A,
+			const Vector< InputType1, banshee, Coords > &x,
+			const Vector< InputType2, banshee, Coords > &y,
+			const Vector< InputType3, banshee, Coords > &z
+		) {
 			auto x_it = x.cbegin();
 			auto y_it = y.cbegin();
 			auto z_it = z.cbegin();
@@ -366,12 +373,12 @@ namespace grb {
 			// TODO issue #64
 			for( ; x_it != x_end; ++x_it ) {
 				assert( *x_it < nrows );
-				(void)++( crs_offsets[ x_it->second ] );
+				(void) ++( crs_offsets[ x_it->second ] );
 			}
 			// TODO issue #64
 			for( ; y_it != y_end; ++y_it ) {
 				assert( *y_it < ncols );
-				(void)++( ccs_offsets[ y_it->second ] );
+				(void) ++( ccs_offsets[ y_it->second ] );
 			}
 			const size_t T = 1;
 			const size_t t = 0;
@@ -388,7 +395,7 @@ namespace grb {
 			if( end > loopsz ) {
 				end = loopsz;
 			}
-			(void)++start;
+			(void) ++start;
 			for( size_t i = start; i < end; ++i ) {
 				crs_offsets[ i ] += crs_offsets[ i - 1 ];
 				ccs_offsets[ i ] += ccs_offsets[ i - 1 ];
@@ -421,7 +428,6 @@ namespace grb {
 			for( size_t i = nmins + start; i < nmins + end; ++i ) {
 				ccs_offsets[ i ] += ccs_offsets[ i - 1 ];
 			}
-			#pragma omp barrier
 			assert( T > 0 );
 			for( size_t k = T - 1; k > 0; --k ) {
 				loopsz = nrows;
@@ -433,7 +439,6 @@ namespace grb {
 				}
 				end = loopsz;
 				assert( start > 0 );
-				#pragma omp for schedule( static, config::CACHE_LINE_SIZE::value() )
 				for( size_t i = start; i < end; ++i ) {
 					crs_offsets[ i ] += crs_offsets[ start - 1 ];
 				}
@@ -446,7 +451,6 @@ namespace grb {
 				}
 				end = loopsz;
 				assert( start > 0 );
-				#pragma omp for schedule( static, config::CACHE_LINE_SIZE::value() )
 				for( size_t i = start; i < end; ++i ) {
 					ccs_offsets[ i ] += ccs_offsets[ start - 1 ];
 				}
@@ -498,17 +502,27 @@ namespace grb {
 			// done
 			return ret;
 		}
+
 	} // namespace internal
 
-	template< Descriptor descr = descriptors::no_operation, typename OutputType, typename InputType1, typename InputType2, typename InputType3, typename Coords >
-	RC zip( Matrix< OutputType, banshee > & A, const Vector< InputType1, banshee, Coords > & x, const Vector< InputType2, banshee, Coords > & y, const Vector< InputType3, banshee, Coords > & z ) {
-		static_assert( ! ( descr & descriptors::no_casting ) || std::is_integral< InputType1 >::value,
+	template<
+		Descriptor descr = descriptors::no_operation,
+		typename OutputType, typename InputType1, typename InputType2, typename InputType3,
+		typename Coords
+	>
+	RC zip(
+		Matrix< OutputType, banshee > &A,
+		const Vector< InputType1, banshee, Coords > &x,
+		const Vector< InputType2, banshee, Coords > &y,
+		const Vector< InputType3, banshee, Coords > &z
+	) {
+		static_assert( !(descr & descriptors::no_casting) || std::is_integral< InputType1 >::value,
 			"grb::zip (two vectors to matrix) called using non-integral left-hand "
 			"vector elements" );
-		static_assert( ! ( descr & descriptors::no_casting ) || std::is_integral< InputType2 >::value,
+		static_assert( !(descr & descriptors::no_casting) || std::is_integral< InputType2 >::value,
 			"grb::zip (two vectors to matrix) called using non-integral right-hand "
 			"vector elements" );
-		static_assert( ! ( descr & descriptors::no_casting ) || std::is_same< OutputType, InputType3 >::value,
+		static_assert( !(descr & descriptors::no_casting) || std::is_same< OutputType, InputType3 >::value,
 			"grb::zip (two vectors to matrix) called with differing vector nonzero "
 			"and output matrix domains" );
 
@@ -534,12 +548,19 @@ namespace grb {
 		return internal::matrix_zip_generic< descr, false >( A, x, y, z );
 	}
 
-	template< Descriptor descr = descriptors::no_operation, typename InputType1, typename InputType2, typename Coords >
-	RC zip( Matrix< void, banshee > & A, const Vector< InputType1, banshee, Coords > & x, const Vector< InputType2, banshee, Coords > & y ) {
-		static_assert( ! ( descr & descriptors::no_casting ) || std::is_integral< InputType1 >::value,
+	template<
+		Descriptor descr = descriptors::no_operation,
+		typename InputType1, typename InputType2, typename Coords
+	>
+	RC zip(
+		Matrix< void, banshee > &A,
+		const Vector< InputType1, banshee, Coords > &x,
+		const Vector< InputType2, banshee, Coords > &y
+	) {
+		static_assert( !(descr & descriptors::no_casting) || std::is_integral< InputType1 >::value,
 			"grb::zip (two vectors to void matrix) called using non-integral "
 			"left-hand vector elements" );
-		static_assert( ! ( descr & descriptors::no_casting ) || std::is_integral< InputType2 >::value,
+		static_assert( !(descr & descriptors::no_casting) || std::is_integral< InputType2 >::value,
 			"grb::zip (two vectors to void matrix) called using non-integral "
 			"right-hand vector elements" );
 

--- a/include/graphblas/reference/blas2.hpp
+++ b/include/graphblas/reference/blas2.hpp
@@ -1189,9 +1189,13 @@ namespace grb {
 							std::cout << s << ": in full CRS variant (gather)\n";
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_BLAS2
-							#pragma omp for schedule( static, config::CACHE_LINE_SIZE::value() ) nowait
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, nrows( A ) );
+#else
+							const size_t start = 0;
+							const size_t end = nrows( A );
 #endif
-							for( size_t i = 0; i < nrows( A ); ++i ) {
+							for( size_t i = start; i < end; ++i ) {
 								vxm_inner_kernel_gather<
 									descr, masked, input_masked, left_handed, One
 								>(
@@ -1207,7 +1211,7 @@ namespace grb {
 								if( asyncAssigns == maxAsyncAssigns ) {
 									// warning: return code ignored for brevity;
 									//         may not be the best thing to do
-									(void)internal::getCoordinates( u ).joinUpdate( local_update );
+									(void) internal::getCoordinates( u ).joinUpdate( local_update );
 									asyncAssigns = 0;
 								}
 #endif
@@ -1391,9 +1395,13 @@ namespace grb {
 							std::cout << s << ": loop over all input matrix columns\n";
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_BLAS2
-							#pragma omp for schedule( static, config::CACHE_LINE_SIZE::value() ) nowait
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, ncols( A ) );
+#else
+							const size_t start = 0;
+							const size_t end = ncols( A );
 #endif
-							for( size_t j = 0; j < ncols( A ); ++j ) {
+							for( size_t j = start; j < end; ++j ) {
 								vxm_inner_kernel_gather<
 									descr, masked, input_masked, left_handed, One
 								>(
@@ -1412,7 +1420,7 @@ namespace grb {
 								if( asyncAssigns == maxAsyncAssigns ) {
 									// warning: return code ignored for brevity;
 									//         may not be the best thing to do
-									(void)internal::getCoordinates( u ).joinUpdate( local_update );
+									(void) internal::getCoordinates( u ).joinUpdate( local_update );
 									asyncAssigns = 0;
 								}
 #endif

--- a/include/graphblas/reference/blas3.hpp
+++ b/include/graphblas/reference/blas3.hpp
@@ -585,6 +585,9 @@ namespace grb {
 				crs_offsets[ i ] += crs_offsets[ i - 1 ];
 				ccs_offsets[ i ] += ccs_offsets[ i - 1 ];
 			}
+#ifdef _H_GRB_REFERENCE_OMP_BLAS3
+			#pragma omp barrier
+#endif
 			assert( nrows >= nmins );
 			config::OMP::localRange( start, end, 0, nrows - nmins );
 			for( size_t i = nmins + start; i < nmins + end; ++i ) {
@@ -595,9 +598,6 @@ namespace grb {
 			for( size_t i = nmins + start; i < nmins + end; ++i ) {
 				ccs_offsets[ i ] += ccs_offsets[ i - 1 ];
 			}
-#ifdef _H_GRB_REFERENCE_OMP_BLAS3
-			#pragma omp barrier
-#endif
 			assert( T > 0 );
 			for( size_t k = T - 1; k > 0; --k ) {
 				config::OMP::localRange( start, end, 0, nrows,
@@ -608,6 +608,7 @@ namespace grb {
 				size_t subloop_start, subloop_end;
 #ifdef _H_GRB_REFERENCE_OMP_BLAS3
 				config::OMP::localRange( subloop_start, subloop_end, start, nrows );
+				#pragma omp barrier
 #else
 				subloop_start = start;
 				subloop_end = nrows;
@@ -651,16 +652,20 @@ namespace grb {
 				if( ret == SUCCESS && x_it->first != y_it->first ) {
 					ret = ILLEGAL;
 				}
-				if( ! matrix_is_void && ret == SUCCESS && ( x_it->first != z_it->first ) ) {
+				if( !matrix_is_void && ret == SUCCESS && ( x_it->first != z_it->first ) ) {
 					ret = ILLEGAL;
 				}
+				assert( x_it->second < nrows );
+				assert( y_it->second < ncols );
 				const size_t crs_pos = --( crs_offsets[ x_it->second ] );
 				const size_t ccs_pos = --( ccs_offsets[ y_it->second ] );
+				assert( crs_pos < crs_offsets[ nrows ] );
+				assert( ccs_pos < ccs_offsets[ ncols ] );
 				crs_indices[ crs_pos ] = y_it->second;
 				ccs_indices[ ccs_pos ] = x_it->second;
-				if( ! matrix_is_void ) {
+				if( !matrix_is_void ) {
 					crs_values[ crs_pos ] = ccs_values[ ccs_pos ] = z_it->second;
-					(void)++z_it;
+					(void) ++z_it;
 				}
 			}
 
@@ -668,15 +673,31 @@ namespace grb {
 				internal::setCurrentNonzeroes( A, crs_offsets[ nrows ] );
 			}
 
+			// check all inputs are handled
 			assert( x_it == x_end );
 			assert( y_it == y_end );
 			if( !matrix_is_void ) {
 				assert( z_it == z_end );
+			} else {
+				(void) z_end;
 			}
 
-			if( matrix_is_void ) {
-				(void)z_end;
+			// finally, some (expensive) debug checks on the output matrix
+			assert( crs_offsets[ nrows ] == ccs_offsets[ ncols ] );
+#ifndef NDEBUG
+			for( size_t j = 0; j < ncols; ++j ) {
+				for( size_t k = ccs_offsets[ j ]; k < ccs_offsets[ j + 1 ]; ++k ) {
+					assert( k < ccs_offsets[ ncols ] );
+					assert( ccs_indices[ k ] < nrows );
+				}
 			}
+			for( size_t i = 0; i < nrows; ++i ) {
+				for( size_t k = crs_offsets[ i ]; k < crs_offsets[ i + 1 ]; ++k ) {
+					assert( k < crs_offsets[ nrows ] );
+					assert( crs_indices[ k ] < ncols );
+				}
+			}
+#endif
 
 			// done
 			return ret;
@@ -690,7 +711,8 @@ namespace grb {
 		typename InputType2, typename InputType3,
 		typename Coords
 	>
-	RC zip( Matrix< OutputType, reference > &A,
+	RC zip(
+		Matrix< OutputType, reference > &A,
 		const Vector< InputType1, reference, Coords > &x,
 		const Vector< InputType2, reference, Coords > &y,
 		const Vector< InputType3, reference, Coords > &z,

--- a/include/graphblas/reference/coordinates.hpp
+++ b/include/graphblas/reference/coordinates.hpp
@@ -613,18 +613,32 @@ namespace grb {
 					}
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-					#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+					#pragma omp parallel
+					{
+						size_t start, end;
+						config::OMP::localRange( start, end, 0, _n );
+#else
+						const size_t start = 0;
+						const size_t end = _n;
 #endif
-					for( size_t k = 0; k < _n; ++k ) {
-						const size_t i = _stack[ k ];
+						for( size_t k = start; k < end; ++k ) {
+							const size_t i = _stack[ k ];
 #ifdef _DEBUG
-						std::cout << "\tProcessing global stack element " << k << " which has index " << i << "."
-							<< " _assigned[ index ] = " << _assigned[ i ] << " and value[ index ] will be set to " << packed_in[ k ] << ".\n";
+ #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
+							#pragma omp critical
+ #endif
+							{
+								std::cout << "\tProcessing global stack element " << k << " which has index " << i << "."
+									<< " _assigned[ index ] = " << _assigned[ i ] << " and value[ index ] will be set to " << packed_in[ k ] << ".\n";
+							}
 #endif
-						assert( i < _cap );
-						_assigned[ i ] = true;
-						array_out[ i ] = packed_in[ k ];
+							assert( i < _cap );
+							_assigned[ i ] = true;
+							array_out[ i ] = packed_in[ k ];
+						}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 					}
+#endif
 					return SUCCESS;
 				}
 
@@ -671,13 +685,22 @@ namespace grb {
 #endif
 					_n = new_nz;
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-					#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+					#pragma omp parallel
+					{
+						size_t start, end;
+						config::OMP::localRange( start, end, 0, _n );
+#else
+						const size_t start = 0;
+						const size_t end = _n;
 #endif
-					for( size_t k = 0; k < _n; ++k ) {
-						const size_t i = _stack[ k ];
-						assert( i < _cap );
-						_assigned[ i ] = true;
+						for( size_t k = start; k < end; ++k ) {
+							const size_t i = _stack[ k ];
+							assert( i < _cap );
+							_assigned[ i ] = true;
+						}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 					}
+#endif
 					return SUCCESS;
 				}
 
@@ -711,15 +734,30 @@ namespace grb {
 					assert( array_in != nullptr );
 					if( _n == _cap ) {
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, _cap );
+#else
+							const size_t start = 0;
+							const size_t end = _cap;
 #endif
-						for( size_t i = 0; i < _cap; ++i ) {
-							stack_out[ i ] = i + offset;
-							packed_out[ i ] = array_in[ i ];
+							for( size_t i = start; i < end; ++i ) {
+								stack_out[ i ] = i + offset;
+								packed_out[ i ] = array_in[ i ];
 #ifdef _DEBUG
-							std::cout << "\t packing local index " << i << " into global index " << stack_out[ i ] << " with nonzero " << packed_out[ i ] << "\n";
+ #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
+								#pragma omp critical
+ #endif
+								{
+									std::cout << "\t packing local index " << i << " into global index "
+										<< stack_out[ i ] << " with nonzero " << packed_out[ i ] << "\n";
+								}
 #endif
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					} else {
 #ifndef NDEBUG
 						if( _assigned == nullptr ) {
@@ -730,17 +768,32 @@ namespace grb {
 						assert( _stack != nullptr );
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, _n );
+#else
+							const size_t start = 0;
+							const size_t end = _n;
 #endif
-						for( size_t k = 0; k < _n; ++ k ) {
-							const size_t i = _stack[ k ];
-							assert( i < _cap );
-							stack_out[ k ] = i + offset;
-							packed_out[ k ] = array_in[ i ];
+							for( size_t k = start; k < end; ++ k ) {
+								const size_t i = _stack[ k ];
+								assert( i < _cap );
+								stack_out[ k ] = i + offset;
+								packed_out[ k ] = array_in[ i ];
 #ifdef _DEBUG
-							std::cout << "\t packing local index " << i << " into global index " << stack_out[ k ] << " with nonzero " << packed_out[ k ] << "\n";
+ #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
+								#pragma omp critical
+ #endif
+								{
+									std::cout << "\t packing local index " << i << " into global index "
+										<< stack_out[ k ] << " with nonzero " << packed_out[ k ] << "\n";
+								}
 #endif
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					}
 					return SUCCESS;
 				}
@@ -763,11 +816,20 @@ namespace grb {
 					assert( stack_out != nullptr );
 					if( _n == _cap ) {
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, _cap );
+#else
+							const size_t start = 0;
+							const size_t end = _cap;
 #endif
-						for( size_t i = 0; i < _cap; ++i ) {
-							stack_out[ i ] = i + offset;
+							for( size_t i = start; i < end; ++i ) {
+								stack_out[ i ] = i + offset;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					} else {
 #ifndef NDEBUG
 						if( _assigned == nullptr ) {
@@ -778,13 +840,22 @@ namespace grb {
 						assert( _stack != nullptr );
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, _n );
+#else
+							const size_t start = 0;
+							const size_t end = _n;
 #endif
-						for( size_t k = 0; k < _n; ++ k ) {
-							const size_t i = _stack[ k ];
-							assert( i < _cap );
-							stack_out[ k ] = i + offset;
+							for( size_t k = start; k < end; ++ k ) {
+								const size_t i = _stack[ k ];
+								assert( i < _cap );
+								stack_out[ k ] = i + offset;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					}
 					return SUCCESS;
 				}
@@ -845,24 +916,47 @@ namespace grb {
 							// is this not totally unnecessary if assuming our structure was cleared first,
 							// and isn't that always the case making this branch therefore dead code?
 							// internal issue #262
-							#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+							#pragma omp parallel
+							{
 #endif
-							for( size_t i = 0; i < offset; ++i ) {
-								_assigned[ i ] = 0;
-							}
+								size_t start, end;
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-							#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+								config::OMP::localRange( start, end, 0, offset );
+#else
+								start = 0;
+								end = offset;
 #endif
-							for( size_t i = offset + localSparsity.size(); i < _cap; ++i ) {
-								_assigned[ i ] = 0;
-							}
+								for( size_t i = start; i < end; ++i ) {
+									_assigned[ i ] = 0;
+								}
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-							#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+								config::OMP::localRange(
+									start, end,
+									offset + localSparsity.size(), _cap
+								);
+#else
+								start = offset + localSparsity.size();
+								end = _cap;
 #endif
-							for( size_t i = 0; i < localSparsity._cap; ++i ) {
-								assert( _assigned[ i + offset ] );
-								_stack[ i ] = i + offset;
+								for( size_t i = start; i < end; ++i ) {
+									_assigned[ i ] = 0;
+								}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
+								config::OMP::localRange( start, end, 0, localSparsity._cap );
+ #ifndef NDEBUG
+								#pragma omp barrier
+ #endif
+#else
+								start = 0;
+								end = localSparsity._cap;
+#endif
+								for( size_t i = start; i < end; ++i ) {
+									assert( _assigned[ i + offset ] );
+									_stack[ i ] = i + offset;
+								}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 							}
+#endif
 							_n = localSparsity._cap;
 							// done
 							return;
@@ -886,17 +980,34 @@ namespace grb {
 						// first, and isn't that always the case making this branch therefore dead
 						// code?
 						// internal issue #262
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
 #endif
-						for( size_t i = 0; i < offset; ++i ) {
-							_assigned[ i ] = 0;
-						}
+							size_t start, end;
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+							config::OMP::localRange( start, end, 0, offset );
+#else
+							start = 0;
+							end = offset;
 #endif
-						for( size_t i = offset + localSparsity.size(); i < _cap; ++i ) {
-							_assigned[ i ] = 0;
+							for( size_t i = start; i < end; ++i ) {
+								_assigned[ i ] = 0;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
+							config::OMP::localRange(
+								start, end,
+								offset + localSparsity.size(), _cap
+							);
+#else
+							start = offset + localSparsity.size();
+							end = _cap;
+#endif
+							for( size_t i = start; i < end; ++i ) {
+								_assigned[ i ] = 0;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					} else {
 #ifdef _DEBUG
 						std::cout << "\t our own sparsity structure was sparse\n";
@@ -1384,11 +1495,20 @@ namespace grb {
 						}
 #endif
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
-						#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+						#pragma omp parallel
+						{
+							size_t start, end;
+							config::OMP::localRange( start, end, 0, _cap );
+#else
+							const size_t start = 0;
+							const size_t end = _cap;
 #endif
-						for( size_t i = 0; i < _cap; ++i ) {
-							_assigned[ i ] = false;
+							for( size_t i = start; i < end; ++i ) {
+								_assigned[ i ] = false;
+							}
+#ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						}
+#endif
 					} else {
 #ifdef _H_GRB_REFERENCE_OMP_COORDINATES
 						if( _n < config::OMP::minLoopSize() ) {

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -395,12 +395,21 @@ namespace grb {
 		const size_t n = internal::getCoordinates( x ).size();
 
 #ifdef _H_GRB_REFERENCE_OMP_IO
-		#pragma omp parallel for schedule( static, config::CACHE_LINE_SIZE::value() )
+		#pragma omp parallel
+		{
+			size_t start, end;
+			config::OMP::localRange( start, end, 0, n );
+#else
+			const size_t start = 0;
+			const size_t end = n;
 #endif
-		for( size_t i = 0; i < n; ++ i ) {
-			raw[ i ] = internal::template ValueOrIndex< descr, DataType, DataType >::
-				getFromScalar( toCopy, i );
+			for( size_t i = start; i < end; ++ i ) {
+				raw[ i ] = internal::template ValueOrIndex< descr, DataType, DataType >::
+					getFromScalar( toCopy, i );
+			}
+#ifdef _H_GRB_REFERENCE_OMP_IO
 		}
+#endif
 		// sanity check
 		assert( internal::getCoordinates( x ).nonzeroes() ==
 			internal::getCoordinates( x ).size() );


### PR DESCRIPTION
In the `reference_omp` backend, as part of the previous merge into develop (#35), Alberto detected that increasing the chunk size of statically-scheduled parallel-for loops could increase the performance noticeably.

The intent of the previous chunk size was to prevent false sharing effects by considering a unit of loop iterands considered by OpenMP to be at least of some size `k`, where `k` is the cache line size. The idea was that then no threads will cause more than O(1) false sharing effects, even if the loop touches single-byte elements-- or indeed zero such effects in the case all memory regions are aligned.

However, despite its name, the OpenMP chunked static schedule introduces a run-time component by assigning the chunks to threads in a round-robin fashion-- aside from run-time overhead, this may also cause more page misses than otherwise would occur.

This MR removes all parallel-fors with static chunked schedules and replaces it with code that only achieves the above intended effect-- a loop is chunked into units of `k` iterands, and then a static schedule is applied on a loop of size `ceil(n/k)`, where `n` is the actual loop size. This is done via the pre-existing (in ALP) `config::OMP::localRange` that was designed to achieve exactly the intended behaviour from within OpenMP parallel sections such as in `vxm_generic`.

This MR also replaces several uses of `#pragma omp for` from within such sections by this pattern.

It also adds some more sanity checking to calls to `grb::zip` (to matrix outputs) and fixes an older version of `grb::zip` still present in the Banshee backend. As always, it also includes some code style fixes across the files that this MR touches.

This resolves internal issue #479.