### PR TITLE
Issue #487: rename z_assigned to z_assign

### DIFF
--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -5160,7 +5160,7 @@ namespace grb {
 		 *
 		 * @tparam assign_y Whether to simply assign to \a y or whether to
 		 *                  (potentially) fold into \a y (in case there are
-		 *                  pre-existing elements
+		 *                  pre-existing elements)
 		 *
 		 * The other arguments pertain to the output, the mask, and the input vectors
 		 * as well as their sizes-- and finally the semiring under which to perform

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -5827,6 +5827,12 @@ namespace grb {
 				m_coors->nonzeroes() == n
 			);
 			const size_t z_nns = nnz( z_vector );
+
+			// the below Boolean shall be true only if the inputs a, x, and y generate
+			// a dense output vector. It furthermore shall be set to false only if the
+			// output vector was either empty or fully dense. This is done to determine
+			// the exact case the dense variant of the eWiseMulAdd implementations can
+			// be used.
 			const bool sparse = ( a_scalar ? false : ( a_coors->nonzeroes() < n ) ) ||
 				( x_scalar ? false : ( x_coors->nonzeroes() < n ) ) ||
 				( y_scalar ? false : ( y_coors->nonzeroes() < n ) ) ||


### PR DESCRIPTION
In eWiseMulAdd's polyalgorithm, the dense variant implements the case where the call generates dense output, but supports to cases regarding the output vector:
  1) on entry the output vector was dense, or
  2) on entry the output vector was totally empty.
The switch on these two cases was handled by `z_assigned` Boolean template argument, but in fact when true was assigning directly to the value arrays of the output vector, which is valid in the case where z initially was empty. Hence `assign_z` (or something like `z_was_empty`) is a more correct name.

This MR changes `z_assigned` into `assign_z` and joins it with some minor code style fixes.

The dispatcher furthermore determines the value of `assign_z` based partially on duplicate code. While if `sparse` is set `z_assign` is not used, this MR clarifies this by setting `assign_z` to true only if also `!sparse`. It also prevents materialising identical sparse variants based on switching `z_assign` there.

Finally, the MR also adds clarifying code documentations. It corresponds to internal issue #487.

Thanks to Aristeidis for reporting.