### PR TITLE
462 copy move assigment of compressed storage iterator is missing the nonzero variable

### DIFF
--- a/include/graphblas/SynchronizedNonzeroIterator.hpp
+++ b/include/graphblas/SynchronizedNonzeroIterator.hpp
@@ -418,6 +418,9 @@ namespace grb {
 
 			public:
 
+				/** ALP value typedef */
+				typedef void ValueType;
+
 				/** The type of this class for a short-hand. */
 				using SelfType = SynchronizedNonzeroIterator<
 					RowIndexT, ColIndexT, void,

--- a/include/graphblas/reference/compressed_storage.hpp
+++ b/include/graphblas/reference/compressed_storage.hpp
@@ -888,6 +888,10 @@ namespace grb {
 
 						/** Move constructor. */
 						ConstIterator( ConstIterator &&other ) {
+#ifdef _DEBUG
+							std::cout << "Iterator move constructor (pattern specialisation) "
+								<< "called\n";
+#endif
 							row_index = std::move( other.row_index );
 							col_start = std::move( other.col_start );
 							k = std::move( other.k );
@@ -951,12 +955,13 @@ namespace grb {
 							s = other.s;
 							P = other.P;
 							nonzero = other.nonzero;
+							return *this;
 						}
 
 						/** Move assignment. */
 						ConstIterator & operator=( ConstIterator &&other ) {
 #ifdef _DEBUG
-							std::cout << "Iterator move-assign operator (pattern specialisation "
+							std::cout << "Iterator move-assign operator (pattern specialisation) "
 								<< "called\n";
 #endif
 							row_index = std::move( other.row_index );
@@ -968,6 +973,7 @@ namespace grb {
 							s = std::move( other.s );
 							P = std::move( other.P );
 							nonzero = std::move( other.nonzero );
+							return *this;
 						}
 
 						/** Whether two iterators compare equal. */

--- a/include/graphblas/reference/compressed_storage.hpp
+++ b/include/graphblas/reference/compressed_storage.hpp
@@ -131,6 +131,11 @@ namespace grb {
 
 					public:
 
+						// ALP typedefs
+						typedef size_t RowIndexType;
+						typedef size_t ColumnIndexType;
+						typedef D ValueType;
+
 						/** Base constructor. */
 						ConstIterator() noexcept : values( nullptr ),
 							row_index( nullptr ), col_start( nullptr ),
@@ -145,11 +150,21 @@ namespace grb {
 							values( other.values ),
 							row_index( other.row_index ), col_start( other.col_start ),
 							k( other.k ), m( other.m ), n( other.n ),
-							row( other.row ), s( other.s ), P( other.P )
-						{}
+							row( other.row ), s( other.s ), P( other.P ),
+							nonzero( other.nonzero )
+						{
+#ifdef _DEBUG
+							std::cout << "Matrix< reference >::const_iterator copy-constructor "
+								<< "called\n";
+#endif
+						}
 
 						/** Move constructor. */
 						ConstIterator( ConstIterator &&other ) {
+#ifdef _DEBUG
+							std::cout << "Matrix< reference >::const_iterator move-constructor "
+								<< "called\n";
+#endif
 							values = std::move( other.values );
 							row_index = std::move( other.row_index );
 							col_start = std::move( other.col_start );
@@ -159,6 +174,7 @@ namespace grb {
 							row = std::move( other.row );
 							s = std::move( other.s );
 							P = std::move( other.P );
+							nonzero = std::move( other.nonzero );
 						}
 
 						/** Non-trivial constructor. */
@@ -214,6 +230,10 @@ namespace grb {
 
 						/** Copy assignment. */
 						ConstIterator & operator=( const ConstIterator &other ) noexcept {
+#ifdef _DEBUG
+							std::cout << "Matrix (reference) const-iterator copy-assign operator "
+								<< "called\n";
+#endif
 							values = other.values;
 							row_index = other.row_index;
 							col_start = other.col_start;
@@ -223,11 +243,16 @@ namespace grb {
 							row = other.row;
 							s = other.s;
 							P = other.P;
+							nonzero = other.nonzero;
 							return *this;
 						}
 
 						/** Move assignment. */
 						ConstIterator & operator=( ConstIterator &&other ) {
+#ifdef _DEBUG
+							std::cout << "Matrix (reference) const-iterator move-assign operator "
+								<< "called\n";
+#endif
 							values = std::move( other.values );
 							row_index = std::move( other.row_index );
 							col_start = std::move( other.col_start );
@@ -237,6 +262,7 @@ namespace grb {
 							row = std::move( other.row );
 							s = std::move( other.s );
 							P = std::move( other.P );
+							nonzero = other.nonzero;
 							return *this;
 						}
 
@@ -344,6 +370,21 @@ namespace grb {
 						operator->() const noexcept {
 							assert( row < m );
 							return &nonzero;
+						}
+
+						/** ALP-specific extension that returns the row coordinate. */
+						const size_t & i() const noexcept {
+							return nonzero.first.first;
+						}
+
+						/** ALP-specific extension that returns the column coordinate. */
+						const size_t & j() const noexcept {
+							return nonzero.first.second;
+						}
+
+						/** ALP-specific extension that returns the nonzero value. */
+						const D & v() const noexcept {
+							return nonzero.second;
 						}
 
 				};
@@ -813,7 +854,13 @@ namespace grb {
 						/** Current nonzero. */
 						std::pair< size_t, size_t > nonzero;
 
+
 					public:
+
+						// ALP typedefs
+						typedef size_t RowIndexType;
+						typedef size_t ColumnIndexType;
+						typedef void ValueType;
 
 						/** Base constructor. */
 						ConstIterator() noexcept :
@@ -831,7 +878,7 @@ namespace grb {
 						ConstIterator( const ConstIterator &other ) noexcept :
 							row_index( other.row_index ), col_start( other.col_start ),
 							k( other.k ), m( other.m ), n( other.n ), row( other.row ),
-							s( 0 ), P( 1 )
+							s( 0 ), P( 1 ), nonzero( other.nonzero )
 						{
 #ifdef _DEBUG
 							std::cout << "Iterator copy constructor (pattern specialisation) "
@@ -849,6 +896,7 @@ namespace grb {
 							row = std::move( other.row );
 							s = std::move( other.s );
 							P = std::move( other.P );
+							nonzero = std::move( other.nonzero );
 						}
 
 						/** Non-trivial constructor. */
@@ -890,6 +938,10 @@ namespace grb {
 
 						/** Copy assignment. */
 						ConstIterator & operator=( const ConstIterator &other ) noexcept {
+#ifdef _DEBUG
+							std::cout << "Iterator copy-assign operator (pattern specialisation) "
+								<< "called\n";
+#endif
 							row_index = other.row_index;
 							col_start = other.col_start;
 							k = other.k;
@@ -898,10 +950,15 @@ namespace grb {
 							row = other.row;
 							s = other.s;
 							P = other.P;
+							nonzero = other.nonzero;
 						}
 
 						/** Move assignment. */
 						ConstIterator & operator=( ConstIterator &&other ) {
+#ifdef _DEBUG
+							std::cout << "Iterator move-assign operator (pattern specialisation "
+								<< "called\n";
+#endif
 							row_index = std::move( other.row_index );
 							col_start = std::move( other.col_start );
 							k = std::move( other.k );
@@ -910,6 +967,7 @@ namespace grb {
 							row = std::move( other.row );
 							s = std::move( other.s );
 							P = std::move( other.P );
+							nonzero = std::move( other.nonzero );
 						}
 
 						/** Whether two iterators compare equal. */
@@ -987,6 +1045,16 @@ namespace grb {
 						const std::pair< size_t, size_t > * operator->() const noexcept {
 							assert( row < m );
 							return &nonzero;
+						}
+
+						/** ALP-specific extension that returns the row coordinate. */
+						const size_t & i() const noexcept {
+							return nonzero.first;
+						}
+
+						/** ALP-specific extension that returns the column coordinate. */
+						const size_t & j() const noexcept {
+							return nonzero.second;
 						}
 
 				};

--- a/include/graphblas/reference/matrix.hpp
+++ b/include/graphblas/reference/matrix.hpp
@@ -1898,10 +1898,12 @@ namespace grb {
 			 * course, undefined).
 			 * \endparblock
 			 */
-			Matrix( const size_t rows, const size_t columns, const size_t nz ) : Matrix()
+			Matrix( const size_t rows, const size_t columns, const size_t nz ) :
+				Matrix()
 			{
 #ifdef _DEBUG
-				std::cout << "In grb::Matrix constructor (reference, with requested capacity)\n";
+				std::cout << "In grb::Matrix constructor (reference, with requested "
+					<< "capacity)\n";
 #endif
 				initialize( nullptr, rows, columns, nz );
 			}
@@ -1929,7 +1931,7 @@ namespace grb {
 				Matrix( rows, columns, std::max( rows, columns ) )
 			{
 #ifdef _DEBUG
-				std::cerr << "In grb::Matrix constructor (reference, default capacity)\n";
+				std::cout << "In grb::Matrix constructor (reference, default capacity)\n";
 #endif
 			}
 

--- a/tests/unit/matrixIterator.cpp
+++ b/tests/unit/matrixIterator.cpp
@@ -87,11 +87,22 @@ RC checkCopy(
 		!std::is_same< typename IteratorType::ValueType, void >::value,
 	void >::type * = nullptr
 ) {
-	auto copy = it;
+	IteratorType copy;
+	copy = it;
 	grb::RC ret = checkCoordinates( copy, it );
 	if( it.v() != copy.v() ) {
 		std::cerr << "Iterator copy yields values different from original:\n"
 			<< "\t" << it.v() << " != " << copy.v() << ".\n";
+		ret = FAILED;
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	// if copy-assignment was OK, let us try copy construction
+	IteratorType copied( it );
+	ret = checkCoordinates( copied, it );
+	if( it.v() != copied.v() ) {
+		std::cerr << "Iterator copy yields values different from original:\n"
+			<< "\t" << it.v() << " != " << copied.v() << ".\n";
 		ret = FAILED;
 	}
 	return ret;
@@ -104,8 +115,15 @@ RC checkCopy(
 		std::is_same< typename IteratorType::ValueType, void >::value,
 	void >::type * = nullptr
 ) {
-	auto copy = it;
-	return checkCoordinates( copy, it );
+	IteratorType copy;
+	copy = it;
+	grb::RC ret = checkCoordinates( copy, it );
+	if( ret != SUCCESS ) { return ret; }
+
+	// if copy-assignment was OK, let us try copy construction
+	IteratorType copied( it );
+	ret = checkCoordinates( copied, it );
+	return ret;
 }
 
 template< typename IteratorType >
@@ -122,8 +140,18 @@ RC checkMove(
 	grb::RC ret = checkCoordinates( dummy, it, true );
 	if( ret != SUCCESS ) {
 		std::cerr << "Moved iterator yields coordinates different from original:\n"
-			<< "\t" << it.i() << " != " << copy.i() << " AND/OR\n"
-			<< "\t" << it.j() << " != " << copy.j() << ".\n";
+			<< "\t" << it.i() << " != " << dummy.i() << " AND/OR\n"
+			<< "\t" << it.j() << " != " << dummy.j() << ".\n";
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	// if move-assignment was OK, let us now try the move constructor
+	IteratorType moved( std::move( dummy ) );
+	ret = checkCoordinates( moved, it, true );
+	if( ret != SUCCESS ) {
+		std::cerr << "Moved iterator yields coordinates different from original:\n"
+			<< "\t" << it.i() << " != " << moved.i() << " AND/OR\n"
+			<< "\t" << it.j() << " != " << moved.j() << ".\n";
 	}
 	return ret;
 }
@@ -142,13 +170,28 @@ RC checkMove(
 	grb::RC ret = checkCoordinates( dummy, it, true );
 	if( ret != SUCCESS ) {
 		std::cerr << "Moved iterator yields coordinates different from original:\n"
-			<< "\t" << it.i() << " != " << copy.i() << " AND/OR\n"
-			<< "\t" << it.j() << " != " << copy.j() << ".\n";
+			<< "\t" << it.i() << " != " << dummy.i() << " AND/OR\n"
+			<< "\t" << it.j() << " != " << dummy.j() << ".\n";
 	}
 	if( it.v() != dummy.v() ) {
 		std::cerr << "Moved iterator yields values different from original:\n"
 			<< "\t" << it.v() << " != " << dummy.v() << ".\n";
-		ret = FAILED;
+		ret = ret ? ret : FAILED;
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	// if move-assignment was OK, let us now try the move constructor
+	IteratorType moved( std::move( dummy ) );
+	ret = checkCoordinates( moved, it, true );
+	if( ret != SUCCESS ) {
+		std::cerr << "Moved iterator yields coordinates different from original:\n"
+			<< "\t" << it.i() << " != " << moved.i() << " AND/OR\n"
+			<< "\t" << it.j() << " != " << moved.j() << ".\n";
+	}
+	if( it.v() != moved.v() ) {
+		std::cerr << "Moved iterator yields values different from original:\n"
+			<< "\t" << it.v() << " != " << moved.v() << ".\n";
+		ret = ret ? ret : FAILED;
 	}
 	return ret;
 }


### PR DESCRIPTION
Anders reported that copy-assignment of matrix output iterators was not properly implemented -- the local nonzero cache was not updated. The same was true for the copy-constructor, move-constructor, and move-assignment. This MR:
1. fixes all those issues, and 
2. hardens the matrixIterator unit test to test all four of {move,copy}x{assignment,construction} for all combination of pattern- and non-pattern matrices it already was testing for.

Additionally,
3. The assignment operators of the pattern-matrix output iterator specialisation did not return a reference to itself, with this MR also fixed;
4. the matrix output iterator itself now also adheres to the ALP matrix iterator API-- i.e., it defines an i, j, and v member function that return the row, column, and value of a nonzero, respectively. It also now and accordingly defines the `RowIndexType`, `ColumnIndexType`, and `ValueType` typedefs;
5. the SynchronizedNonzeroIterator was missing the ALP `ValueType` typedef for pattern matrices, herewith fixed.

This resolves internal issue #462.