### PR TITLE
464 dense spmv test does not work for ecology2 mtx

### DIFF
--- a/include/graphblas/algorithms/bicgstab.hpp
+++ b/include/graphblas/algorithms/bicgstab.hpp
@@ -314,7 +314,7 @@ namespace grb {
 #ifdef _DEBUG
 				std::cout << "\t\t rho = " << rho << "\n";
 #endif
-				if( ret == SUCCESS && utils::equals( rho, zero, 2*n-1 ) ) {
+				if( ret == SUCCESS && rho == zero ) {
 					std::cerr << "Error: BiCGstab detects r at iteration " << iterations <<
 						" is orthogonal to r-hat\n";
 					return FAILED;
@@ -346,7 +346,7 @@ namespace grb {
 				// alpha = rho / (rhat, v)
 				alpha = zero;
 				ret = ret ? ret : dot< dense_descr >( alpha, rhat, v, semiring );
-				if( utils::equals( alpha, zero, 2*n-1 ) ) {
+				if( alpha == zero ) {
 					std::cerr << "Error: BiCGstab detects rhat is orthogonal to v=Ap "
 						<< "at iteration " << iterations << ".\n";
 					return FAILED;
@@ -391,7 +391,7 @@ namespace grb {
 #ifdef _DEBUG
 				std::cout << "\t\t (t, s) = " << temp << "\n";
 #endif
-				if( ret == SUCCESS && utils::equals( rho, zero, 2*n-1 ) ) {
+				if( ret == SUCCESS && temp == zero ) {
 					std::cerr << "Error: BiCGstab detects As at iteration " << iterations <<
 						" is orthogonal to s\n";
 					return FAILED;

--- a/include/graphblas/utils.hpp
+++ b/include/graphblas/utils.hpp
@@ -80,12 +80,20 @@ namespace grb {
 		 * their magnitude.
 		 *
 		 * Intuitively, one may take \a epsilons as the sum of the number of
-		 * operations that produced \a a and \a b, if the above assumption holds. The
-		 * resulting bound could be tightened if the magnitudes encountered during
-		 * their computation differ strongly, but note that:
+		 * operations that produced \a a and \a b, if the above assumption holds.
 		 *
-		 * \warning when comparing versus a known absolute error bound, <b>do not
-		 *          this function</b>.
+		 * The resulting bound can be tightened if the magnitudes encountered during
+		 * their computation are much smaller, and are (likely) too tight if those
+		 * magnitudes were much larger instead. In such cases, one should obtain or
+		 * compute a more appropriate error bound, however:
+		 *
+		 * \warning when comparing for equality within a known absolute error bound,
+		 *          <b>do not this function</b>.
+		 *
+		 * \note If such a function is desired, please submit an issue on GitHub or
+		 *       Gitee. The absolute error bound can be provided again via a
+		 *       parameter \a epsilons, but then of a floating-point type instead of
+		 *       the current integer variant.
 		 *
 		 * @tparam T The numerical type.
 		 * @tparam U The integer type used for \a epsilons.
@@ -174,14 +182,16 @@ namespace grb {
 			if( absA > absB ) {
 				if( absB > max - absA ) {
 #ifdef _DEBUG
-					std::cout << "\t Normalising absolute difference by smallest magnitude (I)\n";
+					std::cout << "\t Normalising absolute difference by smallest magnitude "
+						<< "(I)\n";
 #endif
 					return absDiff / absB < eps;
 				}
 			} else {
 				if( absA > max - absB ) {
 #ifdef _DEBUG
-					std::cout << "\t Normalising absolute difference by smallest magnitude (II)\n";
+					std::cout << "\t Normalising absolute difference by smallest magnitude "
+						<< "(II)\n";
 #endif
 					return absDiff / absA < eps;
 				}

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -181,7 +181,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo " "
 
 			echo ">>>      [x]           [ ]       Testing the conjugate gradient algorithm for the input"
-			echo "                                 matrix (17361x17361) taken from gyrom_m.mtx. This test"
+			echo "                                 matrix (17361x17361) taken from gyro_m.mtx. This test"
 			echo "                                 verifies against a ground-truth solution vector. The test"
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"
 			echo "                                 direct-mode file IO."
@@ -212,7 +212,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo " "
 			
 			echo ">>>      [x]           [ ]       Testing the BiCGstab algorithm for the 17361 x 17361 input"
-			echo "                                 matrix gyrom_m.mtx. This test verifies against a ground-"
+			echo "                                 matrix gyro_m.mtx. This test verifies against a ground-"
 			echo "                                 truth solution vector, the same as used for the earlier"
 			echo "                                 conjugate gradient test. Likewise to that one, this test"
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,6 +21,10 @@ set( TEST_CATEGORY "unit" )
 
 
 # list tests, without the CATEROR[IES,Y] keyword (it's now passed via TEST_CATEGORY)
+add_grb_executables( equals equals.cpp
+	BACKENDS reference NO_BACKEND_NAME
+)
+
 add_grb_executables( add15d add15d.cpp
 	BACKENDS reference NO_BACKEND_NAME
 )

--- a/tests/unit/add15m.cpp
+++ b/tests/unit/add15m.cpp
@@ -31,144 +31,146 @@ static const float chk[ 15 ] = { 12.32, 16.43, 12.32, 12.54, 12.21, 14.65, 15.43
 const static double inval[ 15 ] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 static bool err( const float a, const float b ) {
-	return ! grb::utils::equals( a, b, static_cast< float >( 1 ) );
+	return !grb::utils::equals( a, b, 1 );
 }
 
 int main( int argc, char ** argv ) {
-	(void)argc;
-	(void)printf( "Functional test executable: %s\n", argv[ 0 ] );
+	(void) argc;
+	std::cout << "Functional test executable: " << argv[ 0 ] << "\n";
 
 	float out[ 15 ];
 	int error = 0;
 
 	for( size_t i = 0; i < 15; ++i ) {
 		if( err( data1[ i ] + data2[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr, "Sanity check error at position %zd: %lf + %d does not equal %f.\n", i, data1[ i ], data2[ i ], chk[ i ] );
+			std::cerr << "Sanity check error at position " << i << ": " << data1[ i ]
+				<< " + " << data2[ i ] << " does not equal " << chk[ i ] << ".\n";
 			error = 1;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
+	}
 
 	typedef grb::operators::internal::add< double, int, float > internal_op;
 
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	for( size_t i = 0; i < 15; ++i ) {
 		out[ i ] = data2[ i ];
 		internal_op::foldr( &( data1[ i ] ), &( out[ i ] ) );
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Internal foldr check error at position %zd: %lf does not equal "
-				"%lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Internal foldr check error at position " << i << ": "
+				<< chk[ i ] << " does not equal " << out[ i ] << ".\n";
 			error = 2;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
+	}
 
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	for( size_t i = 0; i < 15; ++i ) {
 		out[ i ] = data1[ i ];
 		internal_op::foldl( &( out[ i ] ), &( data2[ i ] ) );
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Internal foldl check error at position %zd: %lf does not equal "
-				"%lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Internal foldl check error at position " << i << ": "
+				<< chk[ i ] << " does not equal " << out[ i ] << ".\n";
 			error = 3;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
+	}
 
 	typedef grb::operators::add< double, int, float > public_op;
 
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	public_op::eWiseApply( data1, data2, out, 15 );
 
 	for( size_t i = 0; i < 15; ++i ) {
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Public operator (apply) check error at position %zd: %lf does not "
-				"equal %lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Public operator (apply) check error at position " << i << ": "
+				<< chk[ i ] << " does not equal " << out[ i ] << ".\n";
 			error = 4;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
+	}
 
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	for( size_t i = 0; i < 15; ++i ) {
-		const enum grb::RC rc = grb::apply< grb::descriptors::no_casting, public_op >( out[ i ], data1[ i ], data2[ i ] );
+		const enum grb::RC rc = grb::apply< grb::descriptors::no_casting, public_op >(
+			out[ i ], data1[ i ], data2[ i ] );
 		if( rc != SUCCESS ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element apply) does not return "
-				"SUCCESS (%d)\n",
-				(int)rc );
+			std::cerr << "Public operator (element-by-element apply) does not return "
+				<< "SUCCESS, but rather " << grb::toString( rc ) << "\n";
 		}
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element apply) check error at "
-				"position %zd: %lf does not equal %lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Public operator (element-by-element apply) check error at "
+				<< "position " << i << ": " << chk[ i ] << " does not equal " << out[ i ]
+				<< ".\n";
 			error = 5;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	}
+
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	for( size_t i = 0; i < 15; ++i ) {
 		out[ i ] = data2[ i ];
 		// note that passing no_casting to the below should result in a compilation error
-		const enum grb::RC rc = grb::foldr< grb::descriptors::no_operation, public_op >( data1[ i ], out[ i ] );
+		const enum grb::RC rc = grb::foldr<
+			grb::descriptors::no_operation, public_op
+		>( data1[ i ], out[ i ] );
 		if( rc != SUCCESS ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element foldr) does not return "
-				"SUCCESS (%d)\n",
-				(int)rc );
+			std::cerr << "Public operator (element-by-element foldr) does not return "
+				<< "SUCCESS, but rather " << grb::toString( rc ) << "\n";
 		}
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element foldr) check error at "
-				"position %zd: %lf does not equal %lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Public operator (element-by-element foldr) check error at "
+				<< "position " << i << ": " << chk[ i ] << " does not equal " << out[ i ]
+				<< ".\n";
 			error = 6;
 		}
 	}
 
-	if( error )
+	if( error ) {
 		return error;
+	}
 
-	(void)memcpy( out, inval, 15 * sizeof( float ) );
+	(void) memcpy( out, inval, 15 * sizeof( float ) );
 	for( size_t i = 0; i < 15; ++i ) {
 		out[ i ] = data1[ i ];
 		// note that passing no_casting to the below should result in a compilation error
-		const enum grb::RC rc = grb::foldl< grb::descriptors::no_operation, public_op >( out[ i ], data2[ i ] );
+		const enum grb::RC rc = grb::foldl<
+			grb::descriptors::no_operation, public_op
+		>( out[ i ], data2[ i ] );
 		if( rc != SUCCESS ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element foldl) does not return "
-				"SUCCESS (%d)\n",
-				(int)rc );
+			std::cerr << "Public operator (element-by-element foldl) does not return "
+				<< "SUCCESS, but rather " << grb::toString( rc ) << "\n";
 		}
 		if( err( out[ i ], chk[ i ] ) ) {
-			(void)fprintf( stderr,
-				"Public operator (element-by-element foldl) check error at "
-				"position %zd: %lf does not equal %lf.\n",
-				i, chk[ i ], out[ i ] );
+			std::cerr << "Public operator (element-by-element foldl) check error at "
+				<< "position " << i << ": " << chk[ i ] << " does not equal " << out[ i ]
+				<< ".\n";
 			error = 7;
 		}
 	}
 
-	if( ! error ) {
-		(void)printf( "Test OK.\n\n" );
+	// done
+	if( !error ) {
+		std::cout << "Test OK\n" << std::endl;
+	} else {
+		std::cerr << std::flush;
+		std::cout << "Test FAILED\n" << std::endl;
 	}
-
 	return error;
 }
+

--- a/tests/unit/dense_spmv.cpp
+++ b/tests/unit/dense_spmv.cpp
@@ -132,9 +132,12 @@ void grbProgram( const struct input &data, struct output &out ) {
 						out.error_code = FAILED;
 					}
 				} else {
-					const double releps = pair.second == 0 ? 0 : mag[ pair.first ] / fabs(pair.second);
-					const size_t epsilons = static_cast<size_t>(releps * static_cast<double>(cnt[ pair.first ])) + 1;
-					if( ! grb::utils::equals( pair.second, chk[ pair.first ], epsilons ) ) {
+					const size_t epsilons = mag[ pair.first ] < 1
+						? cnt[ pair.first ] + 1
+						: cnt[ pair.first ] * ceil(mag[ pair.first ]) + 1;
+					const double allowedError =
+						epsilons * std::numeric_limits< double >::epsilon();
+					if( std::fabs( pair.second - chk[ pair.first ] ) > allowedError ) {
 						std::cerr << "Verification FAILED ( " << pair.second << " does not equal " << chk[ pair.first ] << " at output vector position " << pair.first << " )\n";
 						out.error_code = FAILED;
 					}

--- a/tests/unit/dense_spmv.cpp
+++ b/tests/unit/dense_spmv.cpp
@@ -38,6 +38,7 @@
 
 #define MAX_FN_LENGTH 512
 
+
 using namespace grb;
 
 struct input {
@@ -472,20 +473,22 @@ int main( int argc, char ** argv ) {
 
 	// start benchmarks
 	grb::Benchmarker< AUTOMATIC > benchmarker;
-	const enum grb::RC rc = benchmarker.exec( &grbProgram, in, out, 1, outer,
-		true );
+	const enum grb::RC rc = benchmarker.exec(
+		&grbProgram, in, out, 1, outer, true
+	);
 	if( rc != SUCCESS ) {
-		std::cerr << "launcher.exec returns with non-SUCCESS error code " << (int)rc
-			<< std::endl;
+		std::cerr << "launcher.exec returns with non-SUCCESS error code "
+			<< grb::toString( rc ) << std::endl;
 		return 50;
 	}
 
 	// done
 	if( out.error_code != SUCCESS ) {
-		std::cout << "Test FAILED\n\n";
+		std::cerr << std::flush;
+		std::cout << "Test FAILED\n" << std::endl;
 		return out.error_code;
 	}
-	std::cout << "Test OK\n\n";
+	std::cout << "Test OK\n" << std::endl;
 	return 0;
 }
 

--- a/tests/unit/equals.cpp
+++ b/tests/unit/equals.cpp
@@ -1,0 +1,277 @@
+
+/*
+ *   Copyright 2021 Huawei Technologies Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <cmath>
+
+#include <graphblas/utils.hpp>
+
+
+/**
+ * Templated tests for floating point types.
+ *
+ * @tparam FloatType A floating point type such as <tt>float</tt> or
+ *                   <tt>double</tt>.
+ *
+ * This function tests for equality, in turn:
+ *   - bit-wise equality (two times);
+ *   - that the two different floats used for bit-wise equality do not equal
+ *     one another;
+ *   - various combinations of equal and non-equal numbers in the subnormal
+ *     range;
+ *   - various combinations of equal and non-equal numbers that when summed
+ *     would overflow;
+ *   - various combinations of equal and non-equal numbers that lie close one
+ *     another, then scaled three orders of magnitude and repeated.
+ *
+ * @returns 0 if all tests pass, and a unique nonzero identifier corresponding
+ *            to the failed test otherwise.
+ */
+template< typename FloatType >
+int floatTest() {
+	int out = 0;
+
+	// bit-wise equality
+	{
+		const FloatType pi = 3.1415926535;
+		const FloatType zero = 0.0;
+		if( !grb::utils::equals( zero, zero, 1 ) ) {
+			std::cerr << "Error during bit-wise equal comparison (I)\n";
+			out = 100;
+		}
+		if( !out && !grb::utils::equals( pi, pi, 1 ) ) {
+			std::cerr << "Error during bit-wise equal comparison (II)\n";
+			out = 110;
+		}
+		if( !out && grb::utils::equals( zero, pi, 1 ) ) {
+			std::cerr << "Error during bit-wise equal comparison (III)\n";
+			out = 120;
+		}
+		if( !out && grb::utils::equals( pi, zero, 1 ) ) {
+			std::cerr << "Error during bit-wise equal comparison (IV)\n";
+			out = 130;
+		}
+	}
+
+	// subnormal comparisons
+	if( out == 0 ) {
+		const FloatType subnormal_two = std::numeric_limits< FloatType >::min() /
+			static_cast< FloatType >( 2 );
+		const FloatType subnormal_four = std::numeric_limits< FloatType >::min() /
+			static_cast< FloatType >( 4 );
+		const FloatType subnormal_five = std::numeric_limits< FloatType >::min() /
+			static_cast< FloatType >( 5 );
+		const FloatType subnormal_ten = std::numeric_limits< FloatType >::min() /
+			static_cast< FloatType >( 10 );
+		const FloatType two = static_cast< FloatType >( 2 );
+		if( grb::utils::equals( subnormal_ten, subnormal_four, 2 ) ) {
+			std::cerr << subnormal_ten << " should not be equal to " << subnormal_four
+				<< " (subnormal I)\n";
+			out = 200;
+		}
+		if( !out && grb::utils::equals( subnormal_four, subnormal_ten, 2 ) ) {
+			std::cerr << subnormal_four << " should not be equal to " << subnormal_ten
+				<< " (subnormal II)\n";
+			out = 210;
+		}
+		const FloatType subnormal_five_too = subnormal_ten * two;
+		if( !out && !grb::utils::equals( subnormal_five_too, subnormal_five, 3 ) ) {
+			std::cerr << subnormal_five_too << " should be equal to " << subnormal_ten
+				<< " (subnormal III)\n";
+			out = 220;
+		}
+		if( !out && !grb::utils::equals( subnormal_five, subnormal_five_too, 3 ) ) {
+			std::cerr << subnormal_ten << " should be equal to " << subnormal_five_too
+				<< " (subnormal IV)\n";
+			out = 230;
+		}
+		const FloatType subnormal1p5 = 1.5 * std::numeric_limits< FloatType >::min();
+		const FloatType subnormal_two_too = subnormal1p5 -
+			std::numeric_limits< FloatType >::min();
+		if( !out && !grb::utils::equals( subnormal_two, subnormal_two_too, 3 ) ) {
+			std::cerr << subnormal_two << " should be equal to " << subnormal_two_too
+				<< " (subnormal V)\n";
+			out = 240;
+		}
+		if( !out && !grb::utils::equals( subnormal_two_too, subnormal_two, 3 ) ) {
+			std::cerr << subnormal_two_too << " should be equal to " << subnormal_two
+				<< " (subnormal VI)\n";
+			out = 250;
+		}
+	}
+
+	// tests with one zero operand
+	if( out == 0 ) {
+		const FloatType zero = 0;
+		const FloatType eps = std::numeric_limits< FloatType >::epsilon();
+		if( grb::utils::equals( zero, eps, 1 ) ) {
+			std::cerr << "Absolute tolerance in epsilons failed (I)\n";
+			out = 300;
+		}
+		if( !out && grb::utils::equals( eps, zero, 1 ) ) {
+			std::cerr << "Absolute tolerance in epsilons failed (II)\n";
+			out = 310;
+		}
+		if( !out && !grb::utils::equals( zero, eps, 2 ) ) {
+			std::cerr << "Absolute tolerance in epsilons failed (III)\n";
+			out = 320;
+		}
+		if( !out && !grb::utils::equals( eps, zero, 2 ) ) {
+			std::cerr << "Absolute tolerance in epsilons failed (IV)\n";
+			out = 330;
+		}
+	}
+
+	// test equality under potential overflow conditions
+	if( out == 0 ) {
+		const FloatType max = std::numeric_limits< FloatType >::max();
+		const FloatType max_three = max / static_cast< FloatType >(3);
+		const FloatType two_max_three = static_cast< FloatType >(2) * max_three;
+		const FloatType max_six = max / static_cast< FloatType >(6);
+		const FloatType four_max_six = static_cast< FloatType >(4) * max_six;
+		const FloatType four_max_six_or_next = four_max_six == two_max_three
+			? nextafter( four_max_six, max )
+			: four_max_six;
+
+		// at this point we computed two-thirds of the max floating point number in
+		// two different ways. If equality normalises by an average of the two
+		// operands then this will overflow-- which of course should not happen.
+		// We use nextafter in case the two computations could take place in exact
+		// arithmetic.
+		if( !grb::utils::equals( two_max_three, four_max_six_or_next, 4 ) ) {
+			std::cerr << "Overflow comparison failed (I)\n";
+			out = 400;
+		}
+		if( !out && !grb::utils::equals( four_max_six_or_next, two_max_three, 4 ) ) {
+			std::cerr << "Overflow comparison failed (II)\n";
+			out = 410;
+		}
+		if( !out && grb::utils::equals( max_three, four_max_six, 3 ) ) {
+			std::cerr << "Overflow comparison failed (III)\n";
+			out = 420;
+		}
+		if( !out && grb::utils::equals( four_max_six, max_three, 3 ) ) {
+			std::cerr << "Overflow comparison failed (IV)\n";
+			out = 430;
+		}
+	}
+
+	// scaling
+	if( out == 0 ) {
+		const FloatType eps = std::numeric_limits< FloatType >::epsilon();
+		const FloatType one = static_cast< FloatType >(1);
+		for( size_t factor = 1; !out && factor < 17; factor += 2 ) {
+			const FloatType onepfac = one + eps * factor;
+			const unsigned int id = (factor - 1) / 2;
+			assert( id < 10 );
+			if( grb::utils::equals( one, onepfac + eps, factor ) ) {
+				std::cerr << "Scaling failed (I, step " << factor << ")\n";
+				out = 500 + id;
+			}
+			if( !out && grb::utils::equals( onepfac + eps, one, factor ) ) {
+				std::cerr << "Scaling failed (II, step " << factor << ")\n";
+				out = 510 + id;
+			}
+			if( !grb::utils::equals( one, onepfac - eps, factor ) ) {
+				std::cerr << "Scaling failed (III, step " << factor << ")\n";
+				out = 520 + id;
+			}
+			if( !out && !grb::utils::equals( onepfac - eps, one, factor ) ) {
+				std::cerr << "Scaling failed (IV, step " << factor << ")\n";
+				out = 530 + id;
+			}
+			constexpr FloatType scale = 1337;
+			if( !out && grb::utils::equals( scale, scale * (onepfac + eps), factor ) ) {
+				std::cerr << "Scaling failed (V, step " << factor << ")\n";
+				out = 540 + id;
+			}
+			if( !out && grb::utils::equals( scale * (onepfac + eps), scale, factor ) ) {
+				std::cerr << "Scaling failed (VI, step " << factor << ")\n";
+				out = 550 + id;
+			}
+			if( !grb::utils::equals( scale, scale * (onepfac - eps), factor ) ) {
+				std::cerr << "Scaling failed (VII, step " << factor << ")\n";
+				out = 560 + id;
+			}
+			if( !out && !grb::utils::equals( scale * (onepfac - eps), scale, factor ) ) {
+				std::cerr << "Scaling failed (VIII, step " << factor << ")\n";
+				out = 570 + id;
+			}
+		}
+	}
+
+	// done
+	return out;
+}
+
+int main( int argc, char ** argv ) {
+	// defaults
+	bool printUsage = false;
+	int out = 0;
+
+	// error checking
+	if( argc != 1 ) {
+		printUsage = true;
+	}
+	if( printUsage ) {
+		std::cerr << "Usage: " << argv[ 0 ] << "\n";
+		return 1;
+	}
+
+	std::cout << "This is functional test " << argv[ 0 ] << "\n";
+
+	// do some basic integer tests
+	const size_t one = 1;
+	const size_t three = 3;
+	if( !grb::utils::equals( three, three ) ) {
+		std::cerr << "Error during equal integer comparison (I)\n";
+		out = 10;
+	}
+	if( out || grb::utils::equals( one, three ) ) {
+		std::cerr << "Error during unequal integer comparison (I)\n";
+		out = 20;
+	}
+	if( out || !grb::utils::equals( one, one ) ) {
+		std::cerr << "Error during equal integer comparison (II)\n";
+		out = 30;
+	}
+	if( out || grb::utils::equals( three, one ) ) {
+		std::cerr << "Error during unequal integer comparison (II)\n";
+		out = 40;
+	}
+
+	// do more involved floating point tests, single precision:
+	out = out ? out : floatTest< float >();
+
+	// double precision (with error code offset):
+	if( out == 0 ) {
+		const int dbl_test = floatTest< double >();
+		if( dbl_test != 0 ) {
+			out = 1000 + dbl_test;
+		}
+	}
+
+	// done
+	if( out != 0 ) {
+		std::cout << "Test FAILED" << std::endl;
+	} else {
+		std::cout << "Test OK" << std::endl;
+	}
+	return out;
+}
+

--- a/tests/unit/unittests.sh
+++ b/tests/unit/unittests.sh
@@ -29,8 +29,8 @@ for MODE in debug ndebug; do
 
 	echo ">>>      [x]           [ ]       Testing grb::utils::equals over floats and doubles"
 	${TEST_BIN_DIR}/equals_${MODE} &> ${TEST_OUT_DIR}/equals_${MODE}.log
-	head -1 {TEST_OUT_DIR}/equals_${MODE}.log
-	grep 'Test OK' {TEST_OUT_DIR}/equals_${MODE}.log || echo "Test FAILED"
+	head -1 ${TEST_OUT_DIR}/equals_${MODE}.log
+	grep 'Test OK' ${TEST_OUT_DIR}/equals_${MODE}.log || echo "Test FAILED"
 
 	echo ">>>      [x]           [ ]       Testing numerical addition operator over doubles"
 	${TEST_BIN_DIR}/add15d_${MODE}

--- a/tests/unit/unittests.sh
+++ b/tests/unit/unittests.sh
@@ -27,6 +27,11 @@ for MODE in debug ndebug; do
 	echo "----------------------------------------------------------------------------------------"
 	echo " "
 
+	echo ">>>      [x]           [ ]       Testing grb::utils::equals over floats and doubles"
+	${TEST_BIN_DIR}/equals_${MODE} &> ${TEST_OUT_DIR}/equals_${MODE}.log
+	head -1 {TEST_OUT_DIR}/equals_${MODE}.log
+	grep 'Test OK' {TEST_OUT_DIR}/equals_${MODE}.log || echo "Test FAILED"
+
 	echo ">>>      [x]           [ ]       Testing numerical addition operator over doubles"
 	${TEST_BIN_DIR}/add15d_${MODE}
 


### PR DESCRIPTION
Anders reported that the `tests/unit/dense_spmv.cpp` failed verification for `ecology2.mtx`. The reason was that the test relies on `grb::utils::equals` to compare numbers vs. an absolute error bound, however, the utility function is written for relative error checking. This MR clarifies the documentation of `grb::utils::equals', and hardens its API somewhat to prevent misuse.

Summarising, this MR:
- implements an absolute error check for `dense_spmv.cpp` instead of relying on `grb::utils::equals`;
- bugfix: BiCGstab also relied on `grb::utils::equals` while it should not;
- bugfix `grb::utils::equals`: the given relative bound was interpreted twice as loose;
- bugfix `grb::utils::equals`: overflow of the normalisation factor was handled questionably;
- testing: unit test added for `grb::utils::equals` to prevent regressions of its implementation;
- code improvement: number of epsilons to `grb::utils::equals` must be integer to help prevent misuse of `grb::utils::equals`;
- tests that did not pass integer epsilons to `grb::utils::equals` are now fixed;
- improved documentation of `grb::utils::equals` to help prevent its misuse.

All unit tests touched were modernised:
- grb::{init,finalize}->grb::Launcher,
- do not use printf/fprintf,
- standardised use of stderr/stdout and test result printing.

Additional loosely related items:
- BiCGstab test for orthogonality (As vs. s) compared the wrong scalar output (was rho, should be temp), now fixed;
- fixed typo in `smoketests.sh` reporting on two related tests.

The MR includes code style fixes through most files it touches.