### PR TITLE
422 clear setelement and usage of pinnedvector leads to segementation fault

### DIFF
--- a/include/graphblas/bsp1d/exec.hpp
+++ b/include/graphblas/bsp1d/exec.hpp
@@ -37,8 +37,9 @@
 #include "init.hpp"
 
 #ifndef _GRB_NO_STDIO
-#include <iostream> //for std::cerr
+ #include <iostream> //for std::cerr
 #endif
+
 
 /** Global internal singleton to track whether MPI was initialized. */
 extern bool _grb_mpi_initialized;
@@ -51,8 +52,8 @@ void _grb_exec_spmd( lpf_t ctx, lpf_pid_t s, lpf_pid_t P, lpf_args_t args ) {
 
 #ifdef _DEBUG
 	if( s == 0 ) {
-		std::cout << "Info: launcher spawned or hooked " << P
-			<< " ALP/GraphBLAS user processes.\n";
+		std::cout << "Info: launcher spawned or hooked " << P << " ALP/GraphBLAS "
+			<< "user processes.\n";
 	}
 #endif
 

--- a/include/graphblas/bsp1d/io.hpp
+++ b/include/graphblas/bsp1d/io.hpp
@@ -189,6 +189,7 @@ namespace grb {
 	RC clear( Vector< DataType, BSP1D, Coords > &x ) noexcept {
 		const RC ret = clear( internal::getLocal( x ) );
 		if( ret == SUCCESS ) {
+			x._became_dense = false;
 			x._cleared = true;
 			internal::signalLocalChange( x );
 		}

--- a/include/graphblas/bsp1d/pinnedvector.hpp
+++ b/include/graphblas/bsp1d/pinnedvector.hpp
@@ -147,9 +147,20 @@ namespace grb {
 				_P = data.P;
 				if( mode != PARALLEL ) {
 					assert( mode == SEQUENTIAL );
-					x.synchronize();
+					const RC rc = x.synchronize();
+					if( rc != SUCCESS ) {
+						throw std::runtime_error(
+							"Could not synchronise vector during pinning: " + toString( rc )
+						);
+					}
 					_buffered_coordinates = x._global._coordinates;
 				} else {
+					const RC rc = x.updateNnz();
+					if( rc != SUCCESS ) {
+						throw std::runtime_error(
+							"Could not update vector nonzero count during pinning: " + toString( rc )
+						);
+					}
 					_buffered_coordinates = x._local._coordinates;
 				}
 			}

--- a/include/graphblas/bsp1d/pinnedvector.hpp
+++ b/include/graphblas/bsp1d/pinnedvector.hpp
@@ -55,10 +55,10 @@ namespace grb {
 			utils::AutoDeleter< IOType > _raw_deleter;
 
 			/**
-			 * Tell the system to delete \a _buffered_coordinates only when we had its
-			 * last reference.
+			 * Tell the system to delete the stack of \a _buffered_coordinates only when
+			 * we had its last reference.
 			 */
-			utils::AutoDeleter< char > _assigned_deleter;
+			utils::AutoDeleter< char > _stack_deleter;
 
 			/** A buffer of the local vector. */
 			IOType * _buffered_values;
@@ -138,7 +138,7 @@ namespace grb {
 			/** \internal No implementation notes. */
 			template< typename Coords >
 			PinnedVector( const Vector< IOType, BSP1D, Coords > &x, const IOMode mode ) :
-				_raw_deleter( x._raw_deleter ), _assigned_deleter( x._assigned_deleter ),
+				_raw_deleter( x._raw_deleter ), _stack_deleter( x._buffer_deleter ),
 				_buffered_values( mode == PARALLEL ? x._raw + x._offset : x._raw ),
 				_mode( mode ), _length( x._global._coordinates.size() )
 			{
@@ -157,7 +157,7 @@ namespace grb {
 			/** \internal No implementation notes. */
 			PinnedVector( const PinnedVector< IOType, BSP1D > &other ) :
 				_raw_deleter( other._raw_deleter ),
-				_assigned_deleter( other._assigned_deleter ),
+				_stack_deleter( other._stack_deleter ),
 				_buffered_values( other._buffered_values ),
 				_buffered_coordinates( other._buffered_coordinates ),
 				_mode( other._mode ), _length( other._length ),
@@ -167,7 +167,7 @@ namespace grb {
 			/** \internal No implementation notes. */
 			PinnedVector( PinnedVector< IOType, BSP1D > &&other ) :
 				_raw_deleter( other._raw_deleter ),
-				_assigned_deleter( other._assigned_deleter ),
+				_stack_deleter( other._stack_deleter ),
 				_buffered_values( other._buffered_values ),
 				//_buffered_coordinates uses std::move, below
 				_mode( other._mode ), _length( other._length ),
@@ -181,7 +181,7 @@ namespace grb {
 				const PinnedVector< IOType, BSP1D > &other
 			) {
 				_raw_deleter = other._raw_deleter;
-				_assigned_deleter = other._assigned_deleter;
+				_stack_deleter = other._stack_deleter;
 				_buffered_values = other._buffered_values;
 				_buffered_coordinates = other._buffered_coordinates;
 				_mode = other._mode;
@@ -196,7 +196,7 @@ namespace grb {
 				PinnedVector< IOType, BSP1D > &&other
 			) {
 				_raw_deleter = other._raw_deleter;
-				_assigned_deleter = other._assigned_deleter;
+				_stack_deleter = other._stack_deleter;
 				_buffered_values = other._buffered_values;
 				_buffered_coordinates = std::move( other._buffered_coordinates );
 				_mode = other._mode;

--- a/include/graphblas/reference/coordinates.hpp
+++ b/include/graphblas/reference/coordinates.hpp
@@ -445,7 +445,10 @@ namespace grb {
 				 *                 valid state.
 				 */
 				void rebuild( const bool dense ) noexcept {
-					// catch most trivial case: a vector of dimension 0, and the dense case
+#ifdef _DEBUG
+					std::cout << "Coordinates::rebuild called with dense = " << dense << "\n";
+#endif
+					// catch most trivial case: a vector of dimension 0 (empty vector)
 					if( _cap == 0 ) {
 						return;
 					}
@@ -456,7 +459,8 @@ namespace grb {
 					}
 					assert( _assigned != nullptr );
 #endif
-					if( dense ) {
+					// catch the other trivial-ish case (since can delegate)
+					if( dense && _n != _cap ) {
 #ifdef _DEBUG
 						std::cout << "rebuildSparsity: dense case\n";
 #endif
@@ -1369,13 +1373,15 @@ namespace grb {
 						assert( t_start < t_end );
 						assert( local_cur < pfBuf[ t_start + 1 ] );
 						for( size_t t_cur = t_start; t_cur < t_end; ++t_cur ) {
+							// The below is a _DEBUG statement that is extremely noisy, yet sometimes
+							// useful. Hence kept disabled by default.
 /*#ifdef _DEBUG
 							#pragma omp critical
 							{
 								std::cout << "\t Thread " << t << " processing nonzero " << global_count
 									<< " / " << global_length << " using the local stack of thread "
 									<< t_cur << " starting from local index " << local_cur << ".\n";
-#endif*///DBG
+#endif*/
 							assert( local_cur <= pfBuf[ t_cur + 1 ] - pfBuf[ t_cur ] );
 							StackType * __restrict__ const cur_stack =
 								_buffer + t_cur * stack_offset + 1;

--- a/include/graphblas/reference/pinnedvector.hpp
+++ b/include/graphblas/reference/pinnedvector.hpp
@@ -53,7 +53,7 @@ namespace grb {
 			 * Tell the system to delete the stack of the \a _buffered_coordinates only
 			 * when we had its last reference.
 			 */
-			utils::AutoDeleter< char > _coordinate_stack;
+			utils::AutoDeleter< char > _stack_deleter;
 
 			/** A buffer of the local vector. */
 			IOType * _buffered_values;
@@ -76,7 +76,7 @@ namespace grb {
 				> > &x,
 				const IOMode mode
 			) :
-				_raw_deleter( x._raw_deleter ), _coordinate_stack( x._buffer_deleter ),
+				_raw_deleter( x._raw_deleter ), _stack_deleter( x._buffer_deleter ),
 				_buffered_values( x._raw ), _buffered_coordinates( x._coordinates )
 			{
 				(void)mode; // sequential and parallel IO mode are equivalent for this

--- a/include/graphblas/reference/pinnedvector.hpp
+++ b/include/graphblas/reference/pinnedvector.hpp
@@ -50,10 +50,10 @@ namespace grb {
 			utils::AutoDeleter< IOType > _raw_deleter;
 
 			/**
-			 * Tell the system to delete \a _buffered_mask only when we had its last
-			 * reference.
+			 * Tell the system to delete the stack of the \a _buffered_coordinates only
+			 * when we had its last reference.
 			 */
-			utils::AutoDeleter< char > _assigned_deleter;
+			utils::AutoDeleter< char > _coordinate_stack;
 
 			/** A buffer of the local vector. */
 			IOType * _buffered_values;
@@ -76,7 +76,7 @@ namespace grb {
 				> > &x,
 				const IOMode mode
 			) :
-				_raw_deleter( x._raw_deleter ), _assigned_deleter( x._assigned_deleter ),
+				_raw_deleter( x._raw_deleter ), _coordinate_stack( x._buffer_deleter ),
 				_buffered_values( x._raw ), _buffered_coordinates( x._coordinates )
 			{
 				(void)mode; // sequential and parallel IO mode are equivalent for this
@@ -131,6 +131,7 @@ namespace grb {
 				assert( _buffered_coordinates.size() > 0 );
 				assert( _buffered_values != nullptr );
 				const size_t index = getNonzeroIndex( k );
+				assert( index < _buffered_coordinates.size() );
 				return _buffered_values[ index ];
 			}
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -249,6 +249,10 @@ add_grb_executables( buildMatrixUnique buildMatrixUnique.cpp
 	ADDITIONAL_LINK_LIBRARIES test_utils
 )
 
+add_grb_executables( pinnedVector pinnedVector.cpp
+	BACKENDS reference reference_omp bsp1d hybrid
+)
+
 # targets to list and build the test for this category
 get_property( unit_tests_list GLOBAL PROPERTY tests_category_unit )
 add_custom_target( "list_tests_category_unit"

--- a/tests/unit/pinnedVector.cpp
+++ b/tests/unit/pinnedVector.cpp
@@ -41,7 +41,8 @@ enum Test {
 	MOST_SPARSE_CLEARED,
 	SPARSE_RANDOM,
 	/** \internal Least sparse, but not dense */
-	LEAST_SPARSE
+	LEAST_SPARSE,
+	LEAST_SPARSE_CLEARED
 };
 
 static const enum Test AllTests[] = {
@@ -53,7 +54,8 @@ static const enum Test AllTests[] = {
 	MOST_SPARSE,
 	MOST_SPARSE_CLEARED,
 	SPARSE_RANDOM,
-	LEAST_SPARSE
+	LEAST_SPARSE,
+	LEAST_SPARSE_CLEARED
 };
 
 constexpr const size_t n = 100009;
@@ -159,6 +161,9 @@ void grbProgram( const struct input< T > &in, struct output< T > &out ) {
 		case LEAST_SPARSE:
 			std::cout << "\t Testing sparse vector with only one unset entry...\n";
 			break;
+		case LEAST_SPARSE_CLEARED:
+			std::cout << "\t Testing cleared vector (from almost-dense)...\n";
+			break;
 		default:
 			assert( false );
 	}
@@ -187,6 +192,7 @@ void grbProgram( const struct input< T > &in, struct output< T > &out ) {
 				break;
 			}
 		case LEAST_SPARSE:
+		case LEAST_SPARSE_CLEARED:
 			{
 				Vector< bool > mask( n );
 				rc = grb::setElement( mask, true, n/2 );
@@ -207,7 +213,8 @@ void grbProgram( const struct input< T > &in, struct output< T > &out ) {
 	if(
 		rc == SUCCESS && (
 			in.test == DENSE_CLEARED ||
-			in.test == MOST_SPARSE_CLEARED
+			in.test == MOST_SPARSE_CLEARED ||
+			in.test == LEAST_SPARSE_CLEARED
 		)
 	) {
 		rc = grb::clear( nonempty );
@@ -226,6 +233,7 @@ void grbProgram( const struct input< T > &in, struct output< T > &out ) {
 			case MOST_SPARSE_CLEARED:
 			case SPARSE_RANDOM:
 			case LEAST_SPARSE:
+			case LEAST_SPARSE_CLEARED:
 				out.vector = PinnedVector< T >( nonempty, SEQUENTIAL );
 				break;
 			case ZERO_CAP:
@@ -273,6 +281,7 @@ int runTests( struct input< T > &in ) {
 			case MOST_SPARSE_CLEARED:
 			case SPARSE_RANDOM:
 			case LEAST_SPARSE:
+			case LEAST_SPARSE_CLEARED:
 				if( out.vector.size() != n ) {
 					std::cerr << "Vector does not have expected capacity\n";
 					rc = FAILED;
@@ -292,6 +301,7 @@ int runTests( struct input< T > &in ) {
 			case ZERO_CAP:
 			case DENSE_CLEARED:
 			case MOST_SPARSE_CLEARED:
+			case LEAST_SPARSE_CLEARED:
 				if( out.vector.nonzeroes() != 0 ) {
 					std::cerr << "Pinned vector has nonzeroes ( " << out.vector.nonzeroes()
 						<< " ), but none were expected\n";
@@ -342,6 +352,8 @@ int runTests( struct input< T > &in ) {
 				case UNPOPULATED:
 				case ZERO_CAP:
 				case DENSE_CLEARED:
+				case MOST_SPARSE_CLEARED:
+				case LEAST_SPARSE_CLEARED:
 					std::cerr << "Iterating over nonzeroes, while none should exist (I)\n";
 					rc = FAILED;
 					break;
@@ -374,6 +386,8 @@ int runTests( struct input< T > &in ) {
 				case UNPOPULATED:
 				case ZERO_CAP:
 				case DENSE_CLEARED:
+				case MOST_SPARSE_CLEARED:
+				case LEAST_SPARSE_CLEARED:
 					std::cerr << "Iterating over nonzeroes, while none should exist (II)\n";
 					rc = FAILED;
 					break;

--- a/tests/unit/pinnedVector.cpp
+++ b/tests/unit/pinnedVector.cpp
@@ -1,0 +1,440 @@
+
+/*
+ *   Copyright 2021 Huawei Technologies Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <cstdlib>
+#include <inttypes.h>
+
+#include <graphblas/algorithms/knn.hpp>
+#include <graphblas/utils/Timer.hpp>
+#include <graphblas/utils/parser.hpp>
+
+#include <graphblas.hpp>
+
+
+using namespace grb;
+using namespace algorithms;
+
+enum Test {
+	EMPTY,
+	UNPOPULATED,
+	ZERO_CAP,
+	DENSE,
+	DENSE_CLEARED,
+	/** \internal Most sparse, but not totally devoid of entries */
+	MOST_SPARSE,
+	MOST_SPARSE_CLEARED,
+	SPARSE_RANDOM,
+	/** \internal Least sparse, but not dense */
+	LEAST_SPARSE
+};
+
+static const enum Test AllTests[] = {
+	EMPTY,
+	UNPOPULATED,
+	ZERO_CAP,
+	DENSE,
+	DENSE_CLEARED,
+	MOST_SPARSE,
+	MOST_SPARSE_CLEARED,
+	SPARSE_RANDOM,
+	LEAST_SPARSE
+};
+
+constexpr const size_t n = 100009;
+
+template< typename T >
+struct input {
+	enum Test test;
+	T element;
+};
+
+template< typename T >
+struct output {
+	RC error_code;
+	PinnedVector< T > vector;
+};
+
+template< typename T >
+static inline bool checkDense( const size_t &i, const T &val, const T &chk ) {
+	if( i >= n ) {
+		std::cerr << "Nonzero with index " << i << ", while "
+			<< "vector size is " << n << "\n";
+		return false;
+	}
+	if( val != chk ) {
+		std::cerr << "Nonzero has unexpected value\n";
+		return false;
+	}
+	return true;
+}
+
+template< typename T >
+static inline bool checkSparse(
+	const size_t &i, const T &val,
+	const T &chk, const enum Test &test
+) {
+	if( val != chk ) {
+		std::cerr << "Nonzero has unexpected value\n";
+		return false;
+	}
+	switch( test ) {
+		case MOST_SPARSE:
+			if( i != n/2 ) {
+				std::cerr << "Nonzero at position " << i << ", expected " << n/2 << "\n";
+				return false;		
+			}
+			break;
+		case SPARSE_RANDOM:
+			if( i > n ) {
+				std::cerr << "Nonzero at invalid position " << i << "; "
+					<< "vector size is " << n << "\n";
+				return false;
+			}
+			break;
+		case LEAST_SPARSE:
+			if( i == n/2 ) {
+				std::cerr << "Nonzero at position " << i << ", while none should be here\n";
+				return false;
+			}
+			break;
+		default:
+			std::cerr << "This could should not be reached\n";
+			assert( false );
+			return false;
+	}
+	return true;
+}
+
+template< typename T >
+void grbProgram( const struct input< T > &in, struct output< T > &out ) {
+	// create container 
+	constexpr const size_t zero = 0;
+	Vector< T > empty( zero ), nonempty( n ), zero_cap( n, zero );
+	srand( 15124 );
+	RC rc = SUCCESS;
+
+	// print progress
+	switch( in.test ) {
+		case EMPTY:
+			std::cout << "\t Testing empty vectors...\n";
+			break;
+		case UNPOPULATED:
+			std::cout << "\t Testing unpopulated vectors...\n";
+			break;
+		case ZERO_CAP:
+			std::cout << "\t Testing zero-capacity vectors...\n";
+			break;
+		case DENSE:
+			std::cout << "\t Testing dense vectors...\n";
+			break;
+		case DENSE_CLEARED:
+			std::cout << "\t Testing cleared vectors...\n";
+			break;
+		case MOST_SPARSE:
+			std::cout << "\t Testing sparse vector with one entry...\n";
+			break;
+		case MOST_SPARSE_CLEARED:
+			std::cout << "\t Testing cleared vectors (from sparse)...\n";
+			break;
+		case SPARSE_RANDOM:
+			std::cout << "\t Testing sparse vector with "
+				<< "randomly positioned entries...\n";
+			break;
+		case LEAST_SPARSE:
+			std::cout << "\t Testing sparse vector with only one unset entry...\n";
+			break;
+		default:
+			assert( false );
+	}
+
+	// initialise
+	switch( in.test ) {
+		case DENSE:
+		case DENSE_CLEARED:
+			{
+				rc = grb::set( nonempty, in.element );
+				break;
+			}
+		case MOST_SPARSE:
+		case MOST_SPARSE_CLEARED:
+			{
+				rc = grb::setElement( nonempty, in.element, n/2 );
+				break;
+			}
+		case SPARSE_RANDOM:
+			{
+				for( size_t i = 0; i < n; ++i ) {
+					if( rand() % 10 == 0 ) {
+						rc = rc ? rc : grb::setElement( nonempty, in.element, i );
+					}
+				}
+				break;
+			}
+		case LEAST_SPARSE:
+			{
+				Vector< bool > mask( n );
+				rc = grb::setElement( mask, true, n/2 );
+				rc = rc ? rc : grb::set<
+						grb::descriptors::invert_mask
+					>( nonempty, mask, in.element );
+				break;
+			}
+		default:
+			assert(
+				in.test == EMPTY ||
+				in.test == UNPOPULATED ||
+				in.test == ZERO_CAP
+			);
+	}
+
+	// clear if requested
+	if(
+		rc == SUCCESS && (
+			in.test == DENSE_CLEARED ||
+			in.test == MOST_SPARSE_CLEARED
+		)
+	) {
+		rc = grb::clear( nonempty );
+	}
+
+	// return as a pinnedVector
+	if( rc == SUCCESS ) {
+		switch( in.test ) {
+			case EMPTY:
+				out.vector = PinnedVector< T >( empty, SEQUENTIAL );
+				break;
+			case UNPOPULATED:
+			case DENSE:
+			case DENSE_CLEARED:
+			case MOST_SPARSE:
+			case MOST_SPARSE_CLEARED:
+			case SPARSE_RANDOM:
+			case LEAST_SPARSE:
+				out.vector = PinnedVector< T >( nonempty, SEQUENTIAL );
+				break;
+			case ZERO_CAP:
+				out.vector = PinnedVector< T >( zero_cap, SEQUENTIAL );
+			break;
+			default:
+				assert( false );
+		}
+	}
+
+	// done
+	out.error_code = rc;
+	return;
+}
+
+template< typename T >
+int runTests( struct input< T > &in ) {
+	struct output< T > out;
+	Launcher< AUTOMATIC > launcher;
+	RC rc = SUCCESS;
+	int offset = 0;
+
+	// for every test
+	for( const auto &test : AllTests ) {
+		// run test
+		in.test = test;
+		rc = rc ? rc : launcher.exec( &grbProgram, in, out );
+		if( out.error_code != SUCCESS ) {
+			return offset + 10;
+		}
+
+		// check size of output vector
+		switch( test ) {
+			case EMPTY:
+				if( out.vector.size() != 0 ) {
+					std::cerr << "Empty pinned vector has nonzero size\n";
+					rc = FAILED;
+				}
+				break;
+			case UNPOPULATED:
+			case ZERO_CAP:
+			case DENSE:
+			case DENSE_CLEARED:
+			case MOST_SPARSE:
+			case MOST_SPARSE_CLEARED:
+			case SPARSE_RANDOM:
+			case LEAST_SPARSE:
+				if( out.vector.size() != n ) {
+					std::cerr << "Vector does not have expected capacity\n";
+					rc = FAILED;
+				}
+				break;
+			default:
+				assert( false );
+		}
+		if( rc != SUCCESS ) {
+			return offset + 20;
+		}
+
+		// check number of nonzeroes
+		switch( test ) {
+			case EMPTY:
+			case UNPOPULATED:
+			case ZERO_CAP:
+			case DENSE_CLEARED:
+			case MOST_SPARSE_CLEARED:
+				if( out.vector.nonzeroes() != 0 ) {
+					std::cerr << "Pinned vector has nonzeroes ( " << out.vector.nonzeroes()
+						<< " ), but none were expected\n";
+					rc = FAILED;
+				}
+				break;
+			case DENSE:
+				if( out.vector.nonzeroes() != n ) {
+					std::cerr << "Pinned vector has less than the expected number of "
+						<< "nonzeroes ( " << out.vector.nonzeroes() << ", expected " << n
+						<< " ).\n";
+					rc = FAILED;
+				}
+				break;
+			case MOST_SPARSE:
+				if( out.vector.nonzeroes() != 1 ) {
+					std::cerr << "Pinned vector has " << out.vector.nonzeroes()
+						<< " nonzeroes, expected 1\n";
+					rc = FAILED;
+				}
+				break;
+			case SPARSE_RANDOM:
+				if( out.vector.nonzeroes() > n ) {
+					std::cerr << "Pinned vector has too many nonzeroes\n";
+					rc = FAILED;
+				}
+				break;
+			case LEAST_SPARSE:
+				if( out.vector.nonzeroes() != n - 1 ) {
+					std::cerr << "Pinned vector has " << out.vector.nonzeroes()
+						<< ", but should have " << (n-1) << "\n";
+					rc = FAILED;
+				}
+				break;
+			default:
+				assert( false );
+		}
+		if( rc != SUCCESS ) {
+			return offset + 30;
+		}
+
+		// check nonzero contents via API
+		for( size_t k = 0; rc == SUCCESS && k < out.vector.nonzeroes(); ++k ) {
+			const size_t index = out.vector.getNonzeroIndex( k );
+			const T value = out.vector.getNonzeroValue( k );
+			switch( test ) {
+				case EMPTY:
+				case UNPOPULATED:
+				case ZERO_CAP:
+				case DENSE_CLEARED:
+					std::cerr << "Iterating over nonzeroes, while none should exist (I)\n";
+					rc = FAILED;
+					break;
+				case DENSE:
+					if( !checkDense( index, value, in.element ) ) {
+						rc = FAILED;
+					}
+					break;
+				case MOST_SPARSE:
+				case SPARSE_RANDOM:
+				case LEAST_SPARSE:
+					if( !checkSparse( index, value, in.element, test ) ) {
+						rc = FAILED;
+					}
+					break;
+				default:
+					assert( false );
+			}
+
+		}
+		if( rc != SUCCESS ) {
+			return offset + 40;
+		}
+
+		// check nonzero contents via iterator
+		// (TODO: this is not yet implemented in PinnedVector-- should we?)
+		/*for( const auto &nonzero : out.vector ) {
+			switch( test ) {
+				case EMPTY:
+				case UNPOPULATED:
+				case ZERO_CAP:
+				case DENSE_CLEARED:
+					std::cerr << "Iterating over nonzeroes, while none should exist (II)\n";
+					rc = FAILED;
+					break;
+				case DENSE:
+					if( !checkDense( nonzero.first, nonzero.second, in.element ) ) {
+						rc = FAILED;
+					}
+					break;
+				case MOST_SPARSE:
+				case SPARSE_RANDOM:
+				case LEAST_SPARSE:
+					if( !checkSparse( nonzero.first, nonzero.second, in.element, test ) ) {
+						rc = FAILED;
+					}
+					break;
+				default:
+					assert( false );
+			}
+			if( rc != SUCCESS ) { break; }
+		}
+		if( rc != SUCCESS ) {
+			return offset + 50;
+		}*/
+
+		offset += 60;
+	}
+	// done
+	return 0;
+}
+
+int main( int argc, char ** argv ) {
+	// sanity check
+	if( argc != 1 ) {
+		std::cout << "Usage: " << argv[ 0 ] << std::endl;
+		return 0;
+	}
+
+	std::cout << "Test executable: " << argv[ 0 ] << "\n";
+
+	// run some tests using a standard elementary type
+	std::cout << "Running test with double vector entries...\n";
+	struct input< double > in_double;
+	in_double.element = 3.1415926535;
+	int error = runTests( in_double );
+
+	// run tests using a non-fundamental type
+	if( error == 0 ) {
+		std::cout << "Running test with std::pair vector entries...\n";
+		struct input< std::pair< size_t, float > > in_pair;
+		in_pair.element = std::make_pair< size_t, float >( 17, -2.7 );
+		error = runTests( in_pair );
+	}
+
+	// done
+	if( error ) {
+		std::cerr << std::flush;
+		std::cout << "Test FAILED\n" << std::endl;
+		return error;
+	} else {
+		std::cout << "Test OK\n" << std::endl;
+		return 0;
+	}
+}
+

--- a/tests/unit/unittests.sh
+++ b/tests/unit/unittests.sh
@@ -31,6 +31,7 @@ for MODE in debug ndebug; do
 	${TEST_BIN_DIR}/equals_${MODE} &> ${TEST_OUT_DIR}/equals_${MODE}.log
 	head -1 ${TEST_OUT_DIR}/equals_${MODE}.log
 	grep 'Test OK' ${TEST_OUT_DIR}/equals_${MODE}.log || echo "Test FAILED"
+	echo " "
 
 	echo ">>>      [x]           [ ]       Testing numerical addition operator over doubles"
 	${TEST_BIN_DIR}/add15d_${MODE}
@@ -184,6 +185,13 @@ for MODE in debug ndebug; do
 				$runner ${TEST_BIN_DIR}/set_${MODE}_${BACKEND} 1000000 &> ${TEST_OUT_DIR}/set_${MODE}_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/set_${MODE}_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/set_${MODE}_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
+				echo " "
+
+				echo ">>>      [x]           [ ]       Testing the grb::pinnedVector on fundamental and"
+				echo "                                 non-fundamental value types."
+				$runner ${TEST_BIN_DIR}/pinnedVector_${MODE}_${BACKEND} &> ${TEST_OUT_DIR}/pinnedVector_${MODE}_${BACKEND}_${P}_${T}.log
+				head -1 ${TEST_OUT_DIR}/pinnedVector_${MODE}_${BACKEND}_${P}_${T}.log
+				grep 'Test OK' ${TEST_OUT_DIR}/pinnedVector_${MODE}_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 				echo " "
 
 				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using (+,0) on vectors"


### PR DESCRIPTION
Aristeidis and Anders reported an issue where combinations of `clear`, `setElement`, and usage of the `PinnedVector` could segfault for the `reference` and `reference_omp` backends. This MR first and foremost introduces a unit test for the `PinnedVector` that operates on vectors of `double`s, vectors of `std::pair`s, and tests it using both the SEQUENTIAL and PARALLEL I/O modes.

This added unit test found or confirmed the following issues, which this MR also fixes:
- `grb::set` (BSP1D) contains code to handle the `use_index` descriptor, but this code should only pass by the compiler if `size_t`s are convertible into the vector element type;
- `grb::PinnedVector` constructor (reference, reference_omp, and BSP1D) should pin the stack, not the bitmask;
- `grb::clear` (BSP1D) did not undo the `became_dense` flag, potentially resulting in a distributed vector that is both cleared and became dense;
- `grb::PinnedVector` constructor (BSP1D) now throws expections instead of silently ignoring errors during construction.

Also minor performance enhancements, code style fixes, better debug tracing, code documentation improvements, and a fixed typo.

This MR closes internal issue #422.