### PR TITLE
Resolve internal issue #495: fold from sparse vectors into scalars using monoids returns illegal

### DIFF
--- a/docs/Suppressions.md
+++ b/docs/Suppressions.md
@@ -57,32 +57,7 @@ These are indirectly caused by the following calls:
 
 These are all OK to suppress since the reads are masked.
 
-5. `include/graphblas/reference/blas1.hpp`, fold_from_vector_to_scalar_generic:
-```
-GRB_UTIL_IGNORE_MAYBE_UNINITIALIZED // the below code ensures to set local
-IOType local;                       // whenever our local block is
-GRB_UTIL_RESTORE_WARNINGS           // non-empty
-if( end > 0 ) {
-	if( i < end ) {
-		local = static_cast< IOType >( internal::getRaw( to_fold )[ i ] );
-	} else {
-		local = static_cast< IOType >( internal::getRaw( to_fold )[ 0 ] );
-	}
-}
-```
-and
-```
-if( root == s ) {
-	// then I should be non-empty
-	assert( !empty );
-	// set global value to locally computed value
-	GRB_UTIL_IGNORE_MAYBE_UNINITIALIZED // one is only root if the local
-	global = local;                     // chunk is non-empty, in which case
-	GRB_UTIL_RESTORE_WARNINGS           // local will be initialised (above)
-	}
-```
-
-6. `include/graphblas/reference/blas1.hpp`, masked_apply_generic:
+5. `include/graphblas/reference/blas1.hpp`, masked_apply_generic:
 ```
 if( mask_b[ t ] ) {
 	// ...

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -589,7 +589,8 @@ namespace grb {
 				"function should not have been called-- please submit a "
 				"bugreport." );
 
-			const size_t n = internal::getCoordinates( to_fold ).size();
+			const size_t n  = internal::getCoordinates( to_fold ).size();
+			const size_t nz = internal::getCoordinates( to_fold ).nonzeroes();
 
 			// mask must be of equal size as input vector
 			if( masked && n != size( mask ) ) {
@@ -608,6 +609,9 @@ namespace grb {
 
 			// handle trivial cases
 			if( n == 0 ) {
+				return SUCCESS;
+			}
+			if( nz == 0 ) {
 				return SUCCESS;
 			}
 			if( masked && !(descr & descriptors::invert_mask) &&
@@ -670,14 +674,14 @@ namespace grb {
 #endif
 					ret = fold_from_vector_to_scalar_vectorDriven< descr, masked, left >(
 						global, to_fold, mask, monoid );
-				} else if( fullLoop >= maskLoop && maskLoop >= vectorLoop ) {
+				} else if( vectorLoop >= fullLoop && maskLoop >= fullLoop ) {
 #ifdef _DEBUG
 					std::cout << "\t dispatching to O(n) sparse variant\n";
 #endif
 					ret = fold_from_vector_to_scalar_fullLoopSparse< descr, masked, left >(
 						global, to_fold, mask, monoid );
 				} else {
-					assert( maskLoop > fullLoop && vectorLoop > fullLoop );
+					assert( maskLoop < fullLoop && maskLoop < vectorLoop );
 					assert( masked );
 #ifdef _DEBUG
 					std::cout << "\t dispatching to mask-driven sparse variant\n";

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -139,7 +139,8 @@ namespace grb {
 
 			// some globals used during the folding
 			RC ret = SUCCESS;
-			IOType global = monoid.template getIdentity< IOType >();
+			typename Monoid::D3 global =
+				monoid.template getIdentity< typename Monoid::D3 >();
 
 #ifndef _H_GRB_REFERENCE_OMP_BLAS1
 			// handle trivial sequential cases
@@ -226,7 +227,8 @@ namespace grb {
 					}
 #endif
 
-					IOType local = monoid.template getIdentity< IOType >();
+					typename Monoid::D3 local =
+						monoid.template getIdentity< typename Monoid::D3 >();
 					if( end > 0 ) {
 						if( i < end ) {
 							local = static_cast< IOType >( internal::getRaw( to_fold )[ i ] );

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -615,7 +615,6 @@ namespace grb {
 				return SUCCESS;
 			}
 			if( masked && !(descr & descriptors::invert_mask) &&
-				(descr & descriptors::structural) &&
 				nnz( mask ) == 0
 			) {
 				return SUCCESS;

--- a/tests/unit/launcher/reduce.cpp
+++ b/tests/unit/launcher/reduce.cpp
@@ -162,6 +162,131 @@ int expect_illegal(
 }
 
 template< Descriptor descr, typename MonT >
+int expect_sparse_success(
+	grb::Vector< double > &xv,
+	MonT &mon,
+	const double check,
+	const grb::Vector< bool > &mask,
+	const double check_unmasked
+) {
+	const size_t nz = grb::nnz( xv );
+	std::cout << "\nStarting functional tests for sparse inputs\n"
+		<< "\t descriptor: " << descr << "\n"
+		<< "\t nonzeroes:  " << nz << "\n"
+		<< "\t checksum 1: " << check << "\n"
+		<< "\t checksum 2: " << check_unmasked << "\n"
+		<< "\t mask:       ";
+	if( grb::size( mask ) > 0 ) {
+		std::cout << grb::nnz( mask ) << " elements.\n";
+	} else {
+		std::cout << "none.\n";
+	}
+
+	double alpha = 3.14;
+	if( grb::foldl< descr >( alpha, xv, mask, mon ) != grb::SUCCESS ) {
+#ifndef NDEBUG
+		const bool sparse_foldl_into_scalar_failed = false;
+		assert( sparse_foldl_into_scalar_failed );
+#endif
+		return 41;
+	}
+
+	double alpha_unmasked = 2.17;
+	if( grb::foldl< descr >( alpha_unmasked, xv, mon ) != grb::SUCCESS ) {
+#ifndef NDEBUG
+		const bool sparse_foldl_into_scalar_unmasked_failed = false;
+		assert( sparse_foldl_into_scalar_unmasked_failed );
+#endif
+		return 46;
+	}
+
+	double alpha_right = -2.22;
+	if( grb::foldr< descr >( xv, mask, alpha_right, mon ) != grb::SUCCESS ) {
+#ifndef NDEBUG
+		const bool sparse_foldr_into_scalar_failed = false;
+		assert( sparse_foldr_into_scalar_failed );
+#endif
+		return 51;
+	}
+
+	double alpha_right_unmasked = -check;
+	if( grb::foldr< descr >( xv, alpha_right_unmasked, mon ) != grb::SUCCESS ) {
+#ifndef NDEBUG
+		const bool sparse_foldr_into_scalar_unmasked_failed = false;
+		assert( sparse_foldr_into_scalar_unmasked_failed );
+#endif
+		return 61;
+	}
+
+	// verify computations
+	alpha -= 3.14;
+	alpha_unmasked -= 2.17;
+	alpha_right += 2.22;
+	alpha_right_unmasked += check;
+	bool error = false;
+	if( !grb::utils::equals( alpha, alpha_right, nz+1 ) ) {
+		std::cerr << "Error: " << alpha_right << " (sparse foldr, masked) "
+			<< " does not equal " << alpha << " (sparse foldl, masked).\n";
+		error = true;
+	}
+	if( !grb::utils::equals( alpha_unmasked, alpha_right_unmasked, nz+1 ) ) {
+		std::cerr << "Error: " << alpha_unmasked << " (sparse foldl, unmasked) "
+			<< "does not equal " << alpha_right_unmasked << " "
+			<< "(sparse foldr, unmasked).\n";
+		error = true;
+	}
+	if( size( mask ) == 0 ) {
+		if( !grb::utils::equals( alpha, alpha_right_unmasked, nz+1 ) ) {
+			std::cerr << "Error: " << alpha_right_unmasked << " "
+				<< "(sparse foldr, unmasked) does not equal " << alpha << " "
+				<< "(sparse foldl, masked).\n";
+			error = true;
+		}
+		if( !grb::utils::equals( alpha, alpha_unmasked, nz+1 ) ) {
+			std::cerr << "Error: " << alpha_unmasked << " (sparse foldl, unmasked) "
+				<< " does not equal " << alpha << " (sparse foldl, masked).\n";
+			error = true;
+		}
+	}
+	if( !grb::utils::equals( check, alpha, nz == 0 ? 1 : nz ) ) {
+		std::cerr << "Error: " << alpha << " does not equal given checksum " << check
+			<< ".\n";
+		error = true;
+	}
+	if( size( mask ) > 0 ) {
+		if( !grb::utils::equals( alpha_unmasked, check_unmasked, nz+1 ) ) {
+			std::cerr << "Error: " << alpha_unmasked << " does not equal given unmasked "
+				<< "checksum " << check_unmasked << ".\n";
+			error = true;
+		}
+		if( !grb::utils::equals( alpha_right_unmasked, check_unmasked, nz+1 ) ) {
+			std::cerr << "Error: " << alpha_right_unmasked << " does not equal given "
+				<< "unmasked checksum " << check_unmasked << ".\n";
+			error = true;
+		}
+	}
+	if( !error ) {
+		if( grb::spmd<>::pid() == 0 ) {
+			std::cout << "Sparse functional tests complete.\n";
+		}
+	} else {
+		std::cerr << std::flush;
+		return 71;
+	}
+	return 0;
+}
+
+template< Descriptor descr, typename MonT >
+int expect_sparse_success(
+	grb::Vector< double > &xv,
+	MonT &mon,
+	const double check,
+	const grb::Vector< bool > mask = NO_MASK
+) {
+	return expect_sparse_success< descr, MonT >( xv, mon, check, mask, check );
+}
+
+template< Descriptor descr, typename MonT >
 int expect_success(
 	grb::Vector< double > &xv,
 	MonT &mon,
@@ -370,6 +495,119 @@ void grbProgram( const size_t &P, int &exit_status ) {
 	if( exit_status != 0 ) {
 		exit_status += 400;
 		return;
+	}
+
+	// do similar happy path testing, but now for sparse inputs
+	{
+		grb::Vector< double > sparse( n ), empty( n ), single( n );
+		grb::Vector< bool > odd_mask( n ), half_mask( n ), full( n );
+		grb::RC rc = grb::set( sparse, even_mask, 1.0 );
+		assert( rc == grb::SUCCESS );
+		rc = rc ? rc : grb::set( full, true );
+		assert( rc == grb::SUCCESS );
+		rc = rc ? rc : grb::setElement( single, 3.141, n/2 );
+		assert( rc == grb::SUCCESS );
+		rc = rc ? rc : grb::setElement( half_mask, true, n/2 );
+		assert( rc == grb::SUCCESS );
+		for( size_t i = 1; rc == grb::SUCCESS && i < n; i += 2 ) {
+			rc = grb::setElement( odd_mask, true, i );
+		}
+		assert( rc == grb::SUCCESS );
+		if( rc != grb::SUCCESS ) {
+			std::cerr << "Could not initialise for sparse tests\n";
+			exit_status = 31;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			empty, realm, 0.0 );
+		if( exit_status != 0 ) {
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			empty, realm, 0.0, even_mask );
+		if( exit_status != 0 ) {
+			exit_status += 100;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			sparse, realm, grb::nnz(sparse) );
+		if( exit_status != 0 ) {
+			exit_status += 200;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			sparse, realm, grb::nnz(sparse), even_mask );
+		if( exit_status != 0 ) {
+			exit_status += 300;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			sparse, realm, 0.0, odd_mask, grb::nnz(sparse) );
+		if( exit_status != 0 ) {
+			exit_status += 400;
+			return;
+		}
+
+		exit_status = expect_sparse_success<
+			grb::descriptors::no_operation | grb::descriptors::structural
+		>(
+			sparse, realm, grb::nnz(sparse), even_mask
+		);
+		if( exit_status != 0 ) {
+			exit_status += 500;
+			return;
+		}
+
+		exit_status = expect_sparse_success<
+			grb::descriptors::no_operation | grb::descriptors::structural
+		>(
+			sparse, realm, 0.0, odd_mask, grb::nnz(sparse)
+		);
+		if( exit_status != 0 ) {
+			exit_status += 600;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::invert_mask >(
+			sparse, realm, grb::nnz(sparse), odd_mask );
+		if( exit_status != 0 ) {
+			exit_status += 700;
+			return;
+		}
+
+		exit_status = expect_sparse_success<
+			grb::descriptors::invert_mask | grb::descriptors::structural
+		>(
+			sparse, realm, grb::nnz(sparse), odd_mask
+		);
+		if( exit_status != 0 ) {
+			exit_status += 800;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::structural >(
+			single, realm, 3.141, full );
+		if( exit_status != 0 ) {
+			exit_status += 900;
+			return;
+		}
+
+		{
+			const double expect = (n/2) % 2 == 0
+				? 1.0
+				: 0.0;
+			exit_status = expect_sparse_success< grb::descriptors::structural >(
+				sparse, realm, expect, half_mask, grb::nnz(sparse) );
+			if( exit_status != 0 ) {
+				exit_status += 1000;
+				return;
+			}
+		}
 	}
 
 	// check whether ILLEGAL is returned when appropriate

--- a/tests/unit/launcher/reduce.cpp
+++ b/tests/unit/launcher/reduce.cpp
@@ -597,14 +597,34 @@ void grbProgram( const size_t &P, int &exit_status ) {
 			return;
 		}
 
+		// warning: below set of two tests alter half_mask
 		{
-			const double expect = (n/2) % 2 == 0
+			double expect = (n/2) % 2 == 0
 				? 1.0
 				: 0.0;
 			exit_status = expect_sparse_success< grb::descriptors::structural >(
 				sparse, realm, expect, half_mask, grb::nnz(sparse) );
 			if( exit_status != 0 ) {
 				exit_status += 1000;
+				return;
+			}
+
+			static_assert( n > 1, "These tests require n=2 or larger" );
+			grb::RC rc = grb::setElement( half_mask, false, n/2 );
+			rc = rc ? rc : grb::setElement( half_mask, true, n/2 + 1 );
+			if( rc == grb::SUCCESS ) {
+				expect = (n/2+1) % 2 == 0
+					? 1.0
+					: 0.0;
+				exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+					sparse, realm, expect, half_mask, grb::nnz(sparse) );
+			} else {
+				exit_status = 1132;
+				return;
+			}
+
+			if( exit_status != 0 ) {
+				exit_status += 1100;
 				return;
 			}
 		}

--- a/tests/unit/launcher/reduce.cpp
+++ b/tests/unit/launcher/reduce.cpp
@@ -417,6 +417,7 @@ void grbProgram( const size_t &P, int &exit_status ) {
 	}
 
 	// done
+	std::cout << "\n";
 	assert( exit_status == 0 );
 }
 

--- a/tests/unit/launcher/reduce.cpp
+++ b/tests/unit/launcher/reduce.cpp
@@ -500,7 +500,7 @@ void grbProgram( const size_t &P, int &exit_status ) {
 	// do similar happy path testing, but now for sparse inputs
 	{
 		grb::Vector< double > sparse( n ), empty( n ), single( n );
-		grb::Vector< bool > odd_mask( n ), half_mask( n ), full( n );
+		grb::Vector< bool > empty_mask( n ), odd_mask( n ), half_mask( n ), full( n );
 		grb::RC rc = grb::set( sparse, even_mask, 1.0 );
 		assert( rc == grb::SUCCESS );
 		rc = rc ? rc : grb::set( full, true );
@@ -540,16 +540,47 @@ void grbProgram( const size_t &P, int &exit_status ) {
 		}
 
 		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
-			sparse, realm, grb::nnz(sparse), even_mask );
+			sparse, realm, 0.0, empty_mask, grb::nnz(sparse) );
 		if( exit_status != 0 ) {
 			exit_status += 300;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::structural >(
+			sparse, realm, 0.0, empty_mask, grb::nnz(sparse) );
+		if( exit_status != 0 ) {
+			exit_status += 400;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::invert_mask >(
+			sparse, realm, grb::nnz(sparse), empty_mask );
+		if( exit_status != 0 ) {
+			exit_status += 500;
+			return;
+		}
+
+		exit_status = expect_sparse_success<
+			grb::descriptors::invert_mask | grb::descriptors::structural
+		>(
+			sparse, realm, grb::nnz(sparse), empty_mask
+		);
+		if( exit_status != 0 ) {
+			exit_status += 600;
+			return;
+		}
+
+		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
+			sparse, realm, grb::nnz(sparse), even_mask );
+		if( exit_status != 0 ) {
+			exit_status += 700;
 			return;
 		}
 
 		exit_status = expect_sparse_success< grb::descriptors::no_operation >(
 			sparse, realm, 0.0, odd_mask, grb::nnz(sparse) );
 		if( exit_status != 0 ) {
-			exit_status += 400;
+			exit_status += 800;
 			return;
 		}
 
@@ -559,7 +590,7 @@ void grbProgram( const size_t &P, int &exit_status ) {
 			sparse, realm, grb::nnz(sparse), even_mask
 		);
 		if( exit_status != 0 ) {
-			exit_status += 500;
+			exit_status += 900;
 			return;
 		}
 
@@ -569,14 +600,14 @@ void grbProgram( const size_t &P, int &exit_status ) {
 			sparse, realm, 0.0, odd_mask, grb::nnz(sparse)
 		);
 		if( exit_status != 0 ) {
-			exit_status += 600;
+			exit_status += 1000;
 			return;
 		}
 
 		exit_status = expect_sparse_success< grb::descriptors::invert_mask >(
 			sparse, realm, grb::nnz(sparse), odd_mask );
 		if( exit_status != 0 ) {
-			exit_status += 700;
+			exit_status += 1100;
 			return;
 		}
 
@@ -586,14 +617,14 @@ void grbProgram( const size_t &P, int &exit_status ) {
 			sparse, realm, grb::nnz(sparse), odd_mask
 		);
 		if( exit_status != 0 ) {
-			exit_status += 800;
+			exit_status += 1200;
 			return;
 		}
 
 		exit_status = expect_sparse_success< grb::descriptors::structural >(
 			single, realm, 3.141, full );
 		if( exit_status != 0 ) {
-			exit_status += 900;
+			exit_status += 1300;
 			return;
 		}
 
@@ -605,7 +636,7 @@ void grbProgram( const size_t &P, int &exit_status ) {
 			exit_status = expect_sparse_success< grb::descriptors::structural >(
 				sparse, realm, expect, half_mask, grb::nnz(sparse) );
 			if( exit_status != 0 ) {
-				exit_status += 1000;
+				exit_status += 1400;
 				return;
 			}
 
@@ -619,12 +650,12 @@ void grbProgram( const size_t &P, int &exit_status ) {
 				exit_status = expect_sparse_success< grb::descriptors::no_operation >(
 					sparse, realm, expect, half_mask, grb::nnz(sparse) );
 			} else {
-				exit_status = 1132;
+				exit_status = 1532;
 				return;
 			}
 
 			if( exit_status != 0 ) {
-				exit_status += 1100;
+				exit_status += 1500;
 				return;
 			}
 		}


### PR DESCRIPTION
This is a regression compared to earlier versions that did accept reducing a sparse vector into a single scalar, using a Monoid structure-- earlier commits reviewed the behaviour under the dense descriptor, but erroneously made fold-into-scalars require dense always. This MR fixes this to only return `ILLEGAL` for sparse input vectors if the dense descriptor is also present.

The MR also found and fixes several bugs:
- casting behaviour was incorrect -- all intermediate results were previously cast to the output scalar type. (Now they are first cast to the monoid output domain.)
- the previously implemented version was not asymptotically optimal in case of sparse vectors and/or masks, now fixed.
- not all trivial cases were caught before dispatching. Prior to this MR this was mostly only a performance bug.

The MR also improves the following items:
- refactor the generic function into a dispatcher, and factored out the dense and sparse variants into separate (internal) functions.
- code previously also allowed sequential dense reductions for associative operators (i.e., non-monoid structures). This is now simplified by assuming monoid structures always, and reduces complexity and performance significantly.
- the unit test for reductions is expanded with testing for sparse vector reductions.

The code simplification described above also removed one previously necessary compiler warning suppression.