### PR TITLE
499 Clean up get_view interface

### DIFF
--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -1112,6 +1112,7 @@ namespace alp {
 				) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based matrix.
 			 *
 			 * @tparam SourceType  The type of the target matrix.
@@ -1352,6 +1353,7 @@ namespace alp {
 				) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based matrix.
 			 *
 			 * @tparam SourceType  The type of the target matrix.
@@ -1585,6 +1587,7 @@ namespace alp {
 				) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based matrix.
 			 *
 			 * @tparam ViewType The dummy View type of the constructed matrix.
@@ -1804,6 +1807,7 @@ namespace alp {
 				) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based matrix.
 			 *
 			 * @tparam ViewType The dummy View type of the constructed matrix.
@@ -2028,6 +2032,7 @@ namespace alp {
 				) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based matrix.
 			 *
 			 * @tparam SourceType  The type of the target matrix.

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -856,7 +856,7 @@ namespace alp {
 			);
 
 			typedef typename std::conditional<
-				View::type_id == view::Views::original,
+				( View::type_id == view::original ) || ( View::type_id == view::gather ),
 				typename storage::AMFFactory::Compose<
 					ImfR, ImfC, typename View::applied_to::amf_type
 				>::amf_type,
@@ -1026,6 +1026,12 @@ namespace alp {
 			};
 
 			template < bool d >
+			struct view_type< view::gather, d > {
+				// View -> view::Gather< self_type > ?
+				using type = Matrix< T, structures::General, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
+			};
+
+			template < bool d >
 			struct view_type< view::transpose, d > {
 				using type = Matrix< T, structures::General, Density::Dense, view::Transpose< self_type >, imf::Id, imf::Id, reference >;
 			};
@@ -1034,11 +1040,6 @@ namespace alp {
 			struct view_type< view::diagonal, d > {
 				// Current solution considering that diagonal is applied directly to rectangular matrices
 				using type = Vector< T, structures::General, Density::Dense, view::Diagonal< self_type >, imf::Strided, imf::Strided, reference >;
-			};
-
-			template < bool d >
-			struct view_type< view::vector, d > {
-				using type = Vector< T, structures::General, Density::Dense, view::Original< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
 			/**
@@ -1263,6 +1264,12 @@ namespace alp {
 			template < bool d >
 			struct view_type< view::original, d > {
 				using type = Matrix< T, structures::Band< Intervals... >, Density::Dense, view::Original< self_type >, imf::Id, imf::Id, reference >;
+			};
+
+			template < bool d >
+			struct view_type< view::gather, d > {
+				// View -> view::Gather< self_type > ?
+				using type = Matrix< T, structures::Band< Intervals... >, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
 			template < bool d >
@@ -1500,6 +1507,12 @@ namespace alp {
 			};
 
 			template < bool d >
+			struct view_type< view::gather, d > {
+				// View -> view::Gather< self_type > ?
+				using type = Matrix< T, structures::Square, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
+			};
+
+			template < bool d >
 			struct view_type< view::transpose, d > {
 				using type = Matrix< T, structures::Square, Density::Dense, view::Transpose< self_type >, imf::Id, imf::Id, reference >;
 			};
@@ -1712,6 +1725,12 @@ namespace alp {
 			template < bool d >
 			struct view_type< view::original, d > {
 				using type = Matrix< T, structures::Symmetric, Density::Dense, view::Original< self_type >, imf::Id, imf::Id, reference >;
+			};
+
+			template < bool d >
+			struct view_type< view::gather, d > {
+				// View -> view::Gather< self_type > ?
+				using type = Matrix< T, structures::Symmetric, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
 			template < bool d >
@@ -1928,6 +1947,12 @@ namespace alp {
 			template < bool d >
 			struct view_type< view::original, d > {
 				using type = Matrix< T, structures::UpperTriangular, Density::Dense, view::Original< self_type >, imf::Id, imf::Id, reference >;
+			};
+
+			template < bool d >
+			struct view_type< view::gather, d > {
+				// View -> view::Gather< self_type > ?
+				using type = Matrix< T, structures::UpperTriangular, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
 			template < bool d >
@@ -2250,7 +2275,7 @@ namespace alp {
 			std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 		>
 		typename internal::new_container_type_from<
-			typename SourceMatrix::template view_type< view::original >::type
+			typename SourceMatrix::template view_type< view::gather >::type
 		>::template change_structure< TargetStructure >::_and_::
 		template change_imfr< TargetImfR >::_and_::
 		template change_imfc< TargetImfC >::type
@@ -2266,7 +2291,7 @@ namespace alp {
 			}
 
 			using target_t = typename internal::new_container_type_from<
-				typename SourceMatrix::template view_type< view::original >::type
+				typename SourceMatrix::template view_type< view::gather >::type
 			>::template change_structure< TargetStructure >::_and_::
 			template change_imfr< TargetImfR >::_and_::
 			template change_imfc< TargetImfC >::type;
@@ -2311,10 +2336,8 @@ namespace alp {
 		std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 	>
 	typename internal::new_container_type_from<
-		typename SourceMatrix::template view_type< view::original >::type
-	>::template change_structure< TargetStructure >::_and_::
-	template change_imfr< imf::Strided >::_and_::
-	template change_imfc< imf::Strided >::type
+		typename SourceMatrix::template view_type< view::gather >::type
+	>::template change_structure< TargetStructure >::type
 	get_view(
 		SourceMatrix &source,
 		const utils::range& rng_r, const utils::range& rng_c
@@ -2360,7 +2383,7 @@ namespace alp {
 		std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 	>
 	typename internal::new_container_type_from<
-		typename SourceMatrix::template view_type< view::original >::type
+		typename SourceMatrix::template view_type< view::gather >::type
 	>::template change_imfr< imf::Strided >::_and_::
 	template change_imfc< imf::Strided >::type
 	get_view(
@@ -2402,13 +2425,17 @@ namespace alp {
 		typename SourceMatrix,
 		std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 	>
-	typename SourceMatrix::template view_type< view::vector >::type
+	typename internal::new_container_type_from<
+		typename SourceMatrix::template view_type< view::gather >::type
+	>::template change_container< alp::Vector >::type
 	get_view(
 		SourceMatrix &source,
 		const size_t &sel_r,
 		const utils::range &rng_c
 	) {
-		using target_t = typename SourceMatrix::template view_type< view::vector >::type;
+		using target_t = typename internal::new_container_type_from<
+			typename SourceMatrix::template view_type< view::gather >::type
+		>::template change_container< alp::Vector >::type;
 
 		return target_t(
 			source,
@@ -2444,13 +2471,18 @@ namespace alp {
 		typename SourceMatrix,
 		std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 	>
-	typename SourceMatrix::template view_type< view::vector >::type
+	typename internal::new_container_type_from<
+		typename SourceMatrix::template view_type< view::gather >::type
+	>::template change_container< alp::Vector >::type
 	get_view(
 		SourceMatrix &source,
 		const utils::range &rng_r,
 		const size_t &sel_c
 	) {
-		using target_t = typename SourceMatrix::template view_type< view::vector >::type;
+		using target_t = typename internal::new_container_type_from<
+			typename SourceMatrix::template view_type< view::gather >::type
+		>::template change_container< alp::Vector >::type;
+
 		return target_t(
 			source,
 			imf::Strided( rng_r.count(), nrows( source ), rng_r.start, rng_r.stride ),
@@ -2484,7 +2516,7 @@ namespace alp {
 		std::enable_if_t< is_matrix< SourceMatrix >::value > * = nullptr
 	>
 	typename internal::new_container_type_from<
-		typename SourceMatrix::template view_type< view::original >::type
+		typename SourceMatrix::template view_type< view::gather >::type
 	>::template change_structure< TargetStructure >::_and_::
 	template change_imfr< imf::Select >::_and_::
 	template change_imfc< imf::Select >::type

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -2151,52 +2151,6 @@ namespace alp {
 
 	} // namespace structures
 
-	namespace internal {
-		/**
-		 * Defines a new ALP container type form the provided original type
-		 * with the modification of the desired nested template parameter.
-		 */
-		template< typename ContainerType >
-		struct new_container_type_from {};
-
-		template<
-			template< typename, typename, enum Density, typename, typename, typename, enum Backend > typename Container,
-			typename T, typename Structure, enum Density density, typename View, typename ImfR, typename ImfC, enum Backend backend
-		>
-		struct new_container_type_from< Container< T, Structure, density, View, ImfR, ImfC, backend > > {
-
-			typedef Container< T, Structure, density, View, ImfR, ImfC, backend > original_container;
-			static_assert( is_matrix< original_container >::value || is_vector< original_container >::value , "ModifyType supports only ALP Matrix and Vector types." );
-
-			template< typename NewStructure >
-			struct change_structure {
-				typedef Container< T, NewStructure, density, View, ImfR, ImfC, backend > type;
-				typedef new_container_type_from< type > _and_;
-			};
-
-			template< typename NewView >
-			struct change_view {
-				typedef Container< T, Structure, density, NewView, ImfR, ImfC, backend > type;
-				typedef new_container_type_from< type > _and_;
-			};
-
-			template< typename NewImfR >
-			struct change_imfr {
-				typedef Container< T, Structure, density, View, NewImfR, ImfC, backend > type;
-				typedef new_container_type_from< type > _and_;
-			};
-
-			template< typename NewImfC >
-			struct change_imfc {
-				typedef Container< T, Structure, density, View, ImfR, NewImfC, backend > type;
-				typedef new_container_type_from< type > _and_;
-			};
-
-			private:
-				new_container_type_from() = delete;
-		};
-	} // namespace internal
-
 	/**
      *
 	 * @brief Generate a view specified by \a target_view where the type is compliant with the

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -1327,8 +1327,8 @@ namespace alp {
 				) {}
 
 			/**
-			 * Constructor for a view over another matrix using default IMFs (Identity).
-			 * Delegate to the general constructor.
+			 * Constructor for a view over another matrix applying a view defined
+			 * by View template parameter of the constructed matrix.
 			 *
 			 * @tparam TargetType  The type of the target matrix.
 			 *
@@ -1342,17 +1342,10 @@ namespace alp {
 				> * = nullptr
 			>
 			Matrix( TargetType &target_matrix ) :
-				Matrix( target_matrix,
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) ) ) {
-
-				static_assert(
-					std::is_same< ImfR, imf::Id >::value &&
-					std::is_same< ImfC, imf::Id >::value,
-					"This constructor can only be used with Id IMFs."
-				);
-
-			}
+				base_type(
+					getContainer( target_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.
@@ -1565,7 +1558,8 @@ namespace alp {
 				) {}
 
 			/**
-			 * Constructor for a view over another matrix using default IMFs (Identity).
+			 * Constructor for a view over another matrix applying a view defined
+			 * by View template parameter of the constructed matrix.
 			 */
 			template<
 				typename TargetType,
@@ -1778,8 +1772,8 @@ namespace alp {
 				) {}
 
 			/**
-			 * Constructor for a view over another matrix using default IMFs (Identity).
-			 * Delegate to the general constructor.
+			 * Constructor for a view over another matrix applying a view defined
+			 * by View template parameter of the constructed matrix.
 			 */
 			template<
 				typename TargetType,
@@ -1790,17 +1784,10 @@ namespace alp {
 				> * = nullptr
 			>
 			Matrix( TargetType &target_matrix ) :
-				Matrix( target_matrix,
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) ) ) {
-
-				static_assert(
-					std::is_same< ImfR, imf::Id >::value &&
-					std::is_same< ImfC, imf::Id >::value,
-					"This constructor can only be used with Id IMFs."
-				);
-
-			}
+				base_type(
+					getContainer( target_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.
@@ -2004,11 +1991,8 @@ namespace alp {
 				) {}
 
 			/**
-			 * Constructor for a view over another matrix using default IMFs (Identity).
-			 * Delegate to the general constructor.
-			 *
-			 * @tparam TargetType  The type of the target matrix.
-			 *
+			 * Constructor for a view over another matrix applying a view defined
+			 * by View template parameter of the constructed matrix.
 			 */
 			template<
 				typename TargetType,
@@ -2019,17 +2003,10 @@ namespace alp {
 				> * = nullptr
 			>
 			Matrix( TargetType &target_matrix ) :
-				Matrix( target_matrix,
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) ) ) {
-
-				static_assert(
-					std::is_same< ImfR, imf::Id >::value &&
-					std::is_same< ImfC, imf::Id >::value,
-					"This constructor can only be used with Id IMFs."
-				);
-
-			}
+				base_type(
+					getContainer( target_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -1021,13 +1021,11 @@ namespace alp {
 
 			template < bool d >
 			struct view_type< view::original, d > {
-				// View -> view::Original< self_type > ?
 				using type = Matrix< T, structures::General, Density::Dense, view::Original< self_type >, imf::Id, imf::Id, reference >;
 			};
 
 			template < bool d >
 			struct view_type< view::gather, d > {
-				// View -> view::Gather< self_type > ?
 				using type = Matrix< T, structures::General, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
@@ -1268,7 +1266,6 @@ namespace alp {
 
 			template < bool d >
 			struct view_type< view::gather, d > {
-				// View -> view::Gather< self_type > ?
 				using type = Matrix< T, structures::Band< Intervals... >, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
@@ -1508,7 +1505,6 @@ namespace alp {
 
 			template < bool d >
 			struct view_type< view::gather, d > {
-				// View -> view::Gather< self_type > ?
 				using type = Matrix< T, structures::Square, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
@@ -1729,7 +1725,6 @@ namespace alp {
 
 			template < bool d >
 			struct view_type< view::gather, d > {
-				// View -> view::Gather< self_type > ?
 				using type = Matrix< T, structures::Symmetric, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 
@@ -1951,7 +1946,6 @@ namespace alp {
 
 			template < bool d >
 			struct view_type< view::gather, d > {
-				// View -> view::Gather< self_type > ?
 				using type = Matrix< T, structures::UpperTriangular, Density::Dense, view::Gather< self_type >, imf::Strided, imf::Strided, reference >;
 			};
 

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -2152,23 +2152,19 @@ namespace alp {
 	} // namespace structures
 
 	/**
-     *
+	 *
 	 * @brief Generate a view specified by \a target_view where the type is compliant with the
 	 * 		  \a source matrix.
 	 * 		  The function guarantees the created view is non-overlapping with other
 	 *        existing views only when the check can be performed in constant time.
 	 *
 	 * @tparam target_view  One of the supported views listed in \a view::Views
-	 * @tparam T            The matrix' elements type
-	 * @tparam Structure    The structure of the source and target matrix view
-	 * @tparam density      The type (i.e., sparse or dense) of storage scheme
-	 * @tparam View         The source's View type
-	 * @tparam backend      The target backend
+	 * @tparam SourceMatrix The type of the source matrix
 	 *
-	 * @param source        The source structured matrix
+	 * @param source        The source ALP matrix
 	 *
 	 * @return A new \a target_view view over the source matrix.
-
+	 *
      * \parblock
      * \par Performance semantics.
      *        -# This function performs
@@ -2182,21 +2178,21 @@ namespace alp {
 	 */
 	template<
 		enum view::Views target_view = view::Views::original,
-		typename SourceMatrixType,
-		std::enable_if_t< is_matrix< SourceMatrixType >::value, void > * = nullptr
+		typename SourceMatrix,
+		std::enable_if_t< is_matrix< SourceMatrix >::value, void > * = nullptr
 	>
-	typename SourceMatrixType::template view_type< target_view >::type
-	get_view( SourceMatrixType &source ) {
+	typename SourceMatrix::template view_type< target_view >::type
+	get_view( SourceMatrix&source ) {
 
-		using target_strmat_t = typename SourceMatrixType::template view_type< target_view >::type;
+		using target_strmat_t = typename SourceMatrix::template view_type< target_view >::type;
 
 		return target_strmat_t( source );
 	}
 
 	/**
-     *
+	 *
 	 * @brief Generate an original view where the type is compliant with the source Matrix.
-	 * 		  Version where a target structure is specified. It can only generate a valide type if the target
+	 * 		  Version where a target structure is specified. It can only generate a valid type if the target
 	 * 		  structure is the same as the source's
 	 * 		  or a more specialized one that would preserve its static properties (e.g., symmetric reference
 	 * 		  to a square matrix -- any assumption based on symmetry would not break those based on square).
@@ -2205,15 +2201,11 @@ namespace alp {
 	 *
 	 * @tparam TargetStructure  The target structure of the new view. It should verify
 	 *                          <code> alp::is_in<Structure, TargetStructure::inferred_structures> </code>.
-	 * @tparam T                The matrix's elements type
-	 * @tparam Structure        The structure of the source and target matrix view
-	 * @tparam density          The type (i.e., \a alp::Density:Dense or \a alp::Density:Sparse) of storage scheme
-	 * @tparam View             The source's View type
-	 * @tparam backend          The target backend
+	 * @tparam SourceMatrix     The type of the source matrix
 	 *
-	 * @param source            The source structured matrix
+	 * @param source            The source ALP matrix
 	 *
-	 * @return A new original view over the source structured matrix.
+	 * @return A new original view over the source ALP matrix.
 	 *
      * \parblock
      * \par Performance semantics.
@@ -2247,11 +2239,11 @@ namespace alp {
 	}
 
 	namespace internal {
+
 		/**
 		 * Implement a gather through a View over compatible Structure using provided Index Mapping Functions.
 		 * The compatibility depends on the TargetStructure, SourceStructure and IMFs, and is calculated during runtime.
 		 */
-
 		template<
 			typename TargetStructure, typename TargetImfR, typename TargetImfC,
 			typename SourceMatrix,
@@ -2294,17 +2286,13 @@ namespace alp {
 	 *
 	 * @tparam TargetStructure  The target structure of the new view. It should verify
 	 *                          <code> alp::is_in<Structure, TargetStructure::inferred_structures> </code>.
-	 * @tparam T                The matrix' elements type
-	 * @tparam Structure        The structure of the source and target matrix view
-	 * @tparam density          The type (i.e., sparse or dense) of storage scheme
-	 * @tparam View             The source's View type
-	 * @tparam backend          The target backend
+	 * @tparam SourceMatrix     The type of source ALP matrix
 	 *
-	 * @param source            The source structured matrix
+	 * @param source            The source ALP matrix
 	 * @param rng_r             A valid range of rows
 	 * @param rng_c             A valid range of columns
 	 *
-	 * @return A new original view over the source structured matrix.
+	 * @return A new original view over the source ALP matrix.
 	 *
      * \parblock
      * \par Performance semantics.
@@ -2347,11 +2335,7 @@ namespace alp {
 	 * A structure preserving check as well as non-overlapping checks with existing views of \a source
 	 * are guaranteed only when each one of them incurs constant time work.
 	 *
-	 * @tparam T          The matrix' elements type
-	 * @tparam Structure  The structure of the source and target matrix view
-	 * @tparam density    The type (i.e., sparse or dense) of storage scheme
-	 * @tparam View       The source's View type
-	 * @tparam backend    The target backend
+	 * @tparam SourceMatrix     The type of source ALP matrix
 	 *
 	 * @param source      The source matrix
 	 * @param rng_r       A valid range of rows
@@ -2395,17 +2379,13 @@ namespace alp {
 	 *
 	 * @brief Generate a vector view on a row of the source matrix.
 	 *
-	 * @tparam T          The matrix' elements type
-	 * @tparam Structure  The structure of the source and target matrix view
-	 * @tparam density    The type (i.e., sparse or dense) of storage scheme
-	 * @tparam View       The source's View type
-	 * @tparam backend    The target backend
+	 * @tparam SourceMatrix The type of the source ALP matrix
 	 *
-	 * @param source      The source matrix
-	 * @param sel_r       A valid row index
-	 * @param rng_c       A valid range of columns
+	 * @param source        The source matrix
+	 * @param sel_r         A valid row index
+	 * @param rng_c         A valid range of columns
 	 *
-	 * @return A new original view over the source structured matrix.
+	 * @return A new original view over the source ALP matrix.
 	 *
 	 * \parblock
 	 * \par Performance semantics.
@@ -2441,17 +2421,13 @@ namespace alp {
 	 *
 	 * @brief Generate a vector view on a column of the source matrix.
 	 *
-	 * @tparam T          The matrix' elements type
-	 * @tparam Structure  The structure of the source and target matrix view
-	 * @tparam density    The type (i.e., sparse or dense) of storage scheme
-	 * @tparam View       The source's View type
-	 * @tparam backend    The target backend
+	 * @tparam SourceMatrix The type of the source ALP matrix
 	 *
-	 * @param source      The source matrix
-	 * @param rng_r       A valid range of rows
-	 * @param sel_c       A valid column index
+	 * @param source        The source matrix
+	 * @param rng_r         A valid range of rows
+	 * @param sel_c         A valid column index
 	 *
-	 * @return A new original view over the source structured matrix.
+	 * @return A new original view over the source ALP matrix.
 	 *
 	 * \parblock
 	 * \par Performance semantics.
@@ -2484,25 +2460,23 @@ namespace alp {
 
 	/**
 	 *
-		* @brief Generate an original view where the type is compliant with the source Matrix.
-		* Version where a selection of rows and columns expressed as vectors of positions
-		* form a new view with specified target structure.
-		*
-		* @tparam TargetStructure The target structure of the new view. It should verify
-		*                         <code> alp::is_in<Structure, TargetStructure::inferred_structures> </code>.
-		* @tparam T               The matrix' elements type
-		* @tparam Structure       The structure of the source and target matrix view
-		* @tparam density         The type (i.e., sparse or dense) of storage scheme
-		* @tparam View            The source's View type
-		* @tparam backend         The target backend
-		*
-		* @param source           The source structured matrix
-		* @param sel_r            A valid permutation vector of row indeces
-		* @param sel_c            A valid permutation vector of column indeces
-		*
-		* @return A new original view over the source structured matrix.
-		*
-		*/
+	 * @brief Generate an original view where the type is compliant with the source Matrix.
+	 * Version where a selection of rows and columns expressed as vectors of positions
+	 * form a new view with specified target structure.
+	 *
+	 * @tparam TargetStructure The target structure of the new view. It should verify
+	 *                         <code> alp::is_in<Structure, TargetStructure::inferred_structures> </code>.
+	 * @tparam SourceMatrix    The type of the source ALP matrix
+	 * @tparam SelectVectorR   The type of the ALP vector defining permutation for rows
+	 * @tparam SelectVectorC   The type of the ALP vector defining permutation for columns
+	 *
+	 * @param source           The source ALP matrix
+	 * @param sel_r            A valid permutation vector of row indeces
+	 * @param sel_c            A valid permutation vector of column indeces
+	 *
+	 * @return A new original view over the source ALP matrix.
+	 *
+	 */
 	template<
 		typename TargetStructure,
 		typename SourceMatrix,

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -2207,7 +2207,7 @@ namespace alp {
 		std::enable_if_t< is_matrix< SourceMatrix >::value, void > * = nullptr
 	>
 	typename SourceMatrix::template view_type< target_view >::type
-	get_view( SourceMatrix&source ) {
+	get_view( SourceMatrix &source ) {
 
 		using target_strmat_t = typename SourceMatrix::template view_type< target_view >::type;
 
@@ -2286,7 +2286,7 @@ namespace alp {
 			//}
 			// No static check as the compatibility depends on IMF, which is a runtime level parameter
 			//if( ! (TargetStructure::template isInstantiableFrom< Structure >( static_cast< TargetImfR & >( imf_r ), static_cast< TargetImfR & >( imf_c ) ) ) ) {
-			if( ! (structures::isInstantiable< typename SourceMatrix::structure, TargetStructure >::check( static_cast< TargetImfR & >( imf_r ), static_cast< TargetImfR & >( imf_c ) ) ) ) {
+			if( ! (structures::isInstantiable< typename SourceMatrix::structure, TargetStructure >::check( imf_r, imf_c ) ) ) {
 				throw std::runtime_error("Cannot gather into specified TargetStructure from provided SourceStructure and Index Mapping Functions.");
 			}
 

--- a/include/alp/reference/matrix.hpp
+++ b/include/alp/reference/matrix.hpp
@@ -1072,50 +1072,50 @@ namespace alp {
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					storage::AMFFactory::Compose<
-						ImfR, ImfC, typename TargetType::base_type::amf_type
-					>::Create( imf_r, imf_c, internal::getAmf( target_matrix ) )
+						ImfR, ImfC, typename SourceType::base_type::amf_type
+					>::Create( imf_r, imf_c, internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
 			 * Constructor for a view over another matrix applying a view defined
 			 * by View template parameter of the constructed matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
+			Matrix( SourceType &source_matrix ) :
 				base_type(
-					getContainer( target_matrix ),
-					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+					getContainer( source_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename SourceType::amf_type >::Create( internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 * @tparam AmfType     The type of the amf used to construct the matrix.
 			 *                     Used as a template parameter to benefit from
 			 *                     SFINAE for the case of FunctorBasedMatrix, when
@@ -1124,17 +1124,17 @@ namespace alp {
 			 *                     result in a hard compilation error.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, AmfType &&amf ) :
+			Matrix( SourceType &source_matrix, AmfType &&amf ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					std::forward< typename base_type::amf_type >( amf )
 				) {
 				static_assert(
@@ -1171,39 +1171,39 @@ namespace alp {
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
-				base_type( getFunctor( target_matrix ), imf_r, imf_c ) {}
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
+				base_type( getFunctor( source_matrix ), imf_r, imf_c ) {}
 
 			/**
 			 * @deprecated
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
-				Matrix( getFunctor( target_matrix ),
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) )
+			Matrix( SourceType &source_matrix ) :
+				Matrix( getFunctor( source_matrix ),
+					imf::Id( nrows ( source_matrix ) ),
+					imf::Id( ncols ( source_matrix ) )
 				) {
 
 				static_assert(
@@ -1307,50 +1307,50 @@ namespace alp {
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					storage::AMFFactory::Compose<
-						ImfR, ImfC, typename TargetType::base_type::amf_type
-					>::Create( imf_r, imf_c, internal::getAmf( target_matrix ) )
+						ImfR, ImfC, typename SourceType::base_type::amf_type
+					>::Create( imf_r, imf_c, internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
 			 * Constructor for a view over another matrix applying a view defined
 			 * by View template parameter of the constructed matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
+			Matrix( SourceType &source_matrix ) :
 				base_type(
-					getContainer( target_matrix ),
-					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+					getContainer( source_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename SourceType::amf_type >::Create( internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 * @tparam AmfType     The type of the amf used to construct the matrix.
 			 *                     Used as a template parameter to benefit from
 			 *                     SFINAE for the case of FunctorBasedMatrix, when
@@ -1359,17 +1359,17 @@ namespace alp {
 			 *                     result in a hard compilation error.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, AmfType &&amf ) :
+			Matrix( SourceType &source_matrix, AmfType &&amf ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					std::forward< typename base_type::amf_type >( amf )
 				) {
 				static_assert(
@@ -1406,38 +1406,38 @@ namespace alp {
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
-				base_type( getFunctor( target_matrix ), imf_r, imf_c ) {}
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
+				base_type( getFunctor( source_matrix ), imf_r, imf_c ) {}
 
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
-				Matrix( getFunctor( target_matrix ),
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) )
+			Matrix( SourceType &source_matrix ) :
+				Matrix( getFunctor( source_matrix ),
+					imf::Id( nrows ( source_matrix ) ),
+					imf::Id( ncols ( source_matrix ) )
 				) {
 
 				static_assert(
@@ -1542,19 +1542,19 @@ namespace alp {
 			 * Constructor for a view over another storage-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					storage::AMFFactory::Compose<
-						ImfR, ImfC, typename TargetType::base_type::amf_type
-					>::Create( imf_r, imf_c, internal::getAmf( target_matrix ) )
+						ImfR, ImfC, typename SourceType::base_type::amf_type
+					>::Create( imf_r, imf_c, internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
@@ -1562,17 +1562,17 @@ namespace alp {
 			 * by View template parameter of the constructed matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
+			Matrix( SourceType &source_matrix ) :
 				base_type(
-					getContainer( target_matrix ),
-					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+					getContainer( source_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename SourceType::amf_type >::Create( internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
@@ -1583,17 +1583,17 @@ namespace alp {
 			 *                 	a view over a storage-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, AmfType &&amf ) :
+			Matrix( SourceType &source_matrix, AmfType &&amf ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					std::forward< typename base_type::amf_type >( amf )
 				) {
 				static_assert(
@@ -1628,31 +1628,31 @@ namespace alp {
 			 * Constructor for a view over another functor-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
-				base_type( getFunctor( target_matrix ), imf_r, imf_c ) {}
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
+				base_type( getFunctor( source_matrix ), imf_r, imf_c ) {}
 
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
-				Matrix( getFunctor( target_matrix ),
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) )
+			Matrix( SourceType &source_matrix ) :
+				Matrix( getFunctor( source_matrix ),
+					imf::Id( nrows ( source_matrix ) ),
+					imf::Id( ncols ( source_matrix ) )
 				) {
 
 				static_assert(
@@ -1756,19 +1756,19 @@ namespace alp {
 			 * Constructor for a view over another storage-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					storage::AMFFactory::Compose<
-						ImfR, ImfC, typename TargetType::base_type::amf_type
-					>::Create( imf_r, imf_c, internal::getAmf( target_matrix ) )
+						ImfR, ImfC, typename SourceType::base_type::amf_type
+					>::Create( imf_r, imf_c, internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
@@ -1776,17 +1776,17 @@ namespace alp {
 			 * by View template parameter of the constructed matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
+			Matrix( SourceType &source_matrix ) :
 				base_type(
-					getContainer( target_matrix ),
-					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+					getContainer( source_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename SourceType::amf_type >::Create( internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
@@ -1799,17 +1799,17 @@ namespace alp {
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, AmfType &&amf ) :
+			Matrix( SourceType &source_matrix, AmfType &&amf ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					std::forward< typename base_type::amf_type >( amf )
 				) {
 				static_assert(
@@ -1844,31 +1844,31 @@ namespace alp {
 			 * Constructor for a view over another functor-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
-				base_type( getFunctor( target_matrix ), imf_r, imf_c ) {}
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
+				base_type( getFunctor( source_matrix ), imf_r, imf_c ) {}
 
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
-				Matrix( getFunctor( target_matrix ),
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) )
+			Matrix( SourceType &source_matrix ) :
+				Matrix( getFunctor( source_matrix ),
+					imf::Id( nrows ( source_matrix ) ),
+					imf::Id( ncols ( source_matrix ) )
 				) {
 
 				static_assert(
@@ -1971,23 +1971,23 @@ namespace alp {
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					storage::AMFFactory::Compose<
-						ImfR, ImfC, typename TargetType::base_type::amf_type
-					>::Create( imf_r, imf_c, internal::getAmf( target_matrix ) )
+						ImfR, ImfC, typename SourceType::base_type::amf_type
+					>::Create( imf_r, imf_c, internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
@@ -1995,38 +1995,38 @@ namespace alp {
 			 * by View template parameter of the constructed matrix.
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
+			Matrix( SourceType &source_matrix ) :
 				base_type(
-					getContainer( target_matrix ),
-					storage::AMFFactory::Reshape< View::type_id, typename TargetType::amf_type >::Create( internal::getAmf( target_matrix ) )
+					getContainer( source_matrix ),
+					storage::AMFFactory::Reshape< View::type_id, typename SourceType::amf_type >::Create( internal::getAmf( source_matrix ) )
 				) {}
 
 			/**
 			 * Constructor for a view over another storage-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 * @tparam AmfType     The type of the amf used to construct the matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, AmfType &&amf ) :
+			Matrix( SourceType &source_matrix, AmfType &&amf ) :
 				base_type(
-					getContainer( target_matrix ),
+					getContainer( source_matrix ),
 					std::forward< typename base_type::amf_type >( amf )
 				) {
 				static_assert(
@@ -2063,38 +2063,38 @@ namespace alp {
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix, ImfR imf_r, ImfC imf_c ) :
-				base_type( getFunctor( target_matrix ), imf_r, imf_c ) {}
+			Matrix( SourceType &source_matrix, ImfR imf_r, ImfC imf_c ) :
+				base_type( getFunctor( source_matrix ), imf_r, imf_c ) {}
 
 			/**
 			 * Constructor for a view over another functor-based matrix.
 			 *
-			 * @tparam TargetType  The type of the target matrix.
+			 * @tparam SourceType  The type of the target matrix.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Matrix( TargetType &target_matrix ) :
-				Matrix( getFunctor( target_matrix ),
-					imf::Id( nrows ( target_matrix ) ),
-					imf::Id( ncols ( target_matrix ) )
+			Matrix( SourceType &source_matrix ) :
+				Matrix( getFunctor( source_matrix ),
+					imf::Id( nrows ( source_matrix ) ),
+					imf::Id( ncols ( source_matrix ) )
 				) {
 
 				static_assert(

--- a/include/alp/reference/vector.hpp
+++ b/include/alp/reference/vector.hpp
@@ -457,6 +457,7 @@ namespace alp {
 				base_type( source_vector ) {}
 
 			/**
+			 * @deprecated
 			 * Constructor for a view over another storage-based vector.
 			 *
 			 * @tparam SourceType  The type of the target vector.

--- a/include/alp/reference/vector.hpp
+++ b/include/alp/reference/vector.hpp
@@ -583,18 +583,15 @@ namespace alp {
 	 *
 	 */
 	template< 
-		typename T, typename Structure, enum Density density, typename View, typename ImfR, typename ImfC,
-		enum Backend backend
+		typename SourceVector,
+		std::enable_if_t< is_vector< SourceVector >::value > * = nullptr
 	>
-	typename Vector< T, Structure, density, View, ImfR, ImfC, backend >::template view_type< view::original >::type
-	get_view( Vector< T, Structure, density, View, ImfR, ImfC, backend > & source ) {
+	typename SourceVector::template view_type< view::original >::type
+	get_view( SourceVector &source ) {
 
-		using source_vec_t = Vector< T, Structure, density, View, ImfR, ImfC, backend >;
-		using target_vec_t = typename source_vec_t::template view_type< view::original >::type;
+		using target_t = typename SourceVector::template view_type< view::original >::type;
 
-		target_vec_t vec_view( source );
-
-		return vec_view;
+		return target_t( source );
 	}
 
 	namespace internal {
@@ -605,34 +602,36 @@ namespace alp {
 		 */
 		template<
 			typename TargetStructure, typename TargetImfR, typename TargetImfC,
-			typename T, typename Structure, enum Density density, typename View, typename ImfR, typename ImfC, enum Backend backend >
-		alp::Vector<
-			T,
-			TargetStructure,
-			density,
-			view::Original< alp::Vector< T, Structure, density, View, ImfR, ImfC, backend > >,
-			TargetImfR,
-			TargetImfC,
-			backend
+			typename SourceVector,
+			std::enable_if_t< is_vector< SourceVector >::value > * = nullptr
 		>
-		get_view( alp::Vector< T, Structure, density, View, ImfR, ImfC, backend > &source,
-				TargetImfR imf_r, TargetImfC imf_c ) {
+		typename internal::new_container_type_from<
+			typename SourceVector::template view_type< view::original >::type
+		>::template change_structure< TargetStructure >::_and_::
+		template change_imfr< TargetImfR >::_and_::
+		template change_imfc< TargetImfC >::type
+		get_view(
+			SourceVector &source,
+			TargetImfR imf_r,
+			TargetImfC imf_c
+		) {
 
 			//if( std::dynamic_pointer_cast< imf::Select >( imf_r ) || std::dynamic_pointer_cast< imf::Select >( imf_c ) ) {
 			//	throw std::runtime_error("Cannot gather with imf::Select yet.");
 			//}
 			// No static check as the compatibility depends on IMF, which is a runtime level parameter
 			//if( ! (TargetStructure::template isInstantiableFrom< Structure >( static_cast< TargetImfR & >( imf_r ), static_cast< TargetImfR & >( imf_c ) ) ) ) {
-			if( ! (structures::isInstantiable< Structure, TargetStructure >::check( static_cast< TargetImfR & >( imf_r ), static_cast< TargetImfR & >( imf_c ) ) ) ) {
+			if( ! (structures::isInstantiable< typename SourceVector::structure, TargetStructure >::check( static_cast< TargetImfR & >( imf_r ), static_cast< TargetImfR & >( imf_c ) ) ) ) {
 				throw std::runtime_error("Cannot gather into specified TargetStructure from provided SourceStructure and Index Mapping Functions.");
 			}
 
-			using source_vec_t = alp::Vector< T, Structure, density, View, ImfR, ImfC, backend >;
-			using target_vec_t = alp::Vector< T, TargetStructure, density, view::Original< source_vec_t >, TargetImfR, TargetImfC, backend >;
+			using target_vec_t = typename internal::new_container_type_from<
+				typename SourceVector::template view_type< view::original >::type
+			>::template change_structure< TargetStructure >::_and_::
+			template change_imfr< TargetImfR >::_and_::
+			template change_imfc< TargetImfC >::type;
 
-			target_vec_t target( source, imf_r, imf_c );
-
-			return target;
+			return target_vec_t( source, imf_r, imf_c );
 		}
 	} // namespace internal
 
@@ -658,21 +657,16 @@ namespace alp {
 	 * 
 	 */
 	template<
-		typename T, typename Structure, enum Density density, typename View, typename ImfR, typename ImfC,
-		enum Backend backend
+		typename SourceVector,
+		std::enable_if_t< is_vector< SourceVector >::value > * = nullptr
 	>
-	Vector<
-		T,
-		Structure,
-		density,
-		view::Original< Vector< T, Structure, density, View, ImfR, ImfC, backend > >,
-		imf::Strided,
-		imf::Strided,
-		backend
-	>
-	get_view( Vector< T, Structure, density, View, ImfR, ImfC, backend > &source, const utils::range& rng ) {
+	typename internal::new_container_type_from<
+		typename SourceVector::template view_type< view::original >::type
+	>::template change_imfr< imf::Strided >::_and_::
+	template change_imfc< imf::Strided >::type
+	get_view( SourceVector &source, const utils::range& rng ) {
 
-		return internal::get_view< Structure >(
+		return internal::get_view< typename SourceVector::structure >(
 			source,
 			std::move( imf::Strided( rng.count(), nrows(source), rng.start, rng.stride ) ),
 			std::move( imf::Strided( rng.count(), ncols(source), rng.start, rng.stride ) )

--- a/include/alp/reference/vector.hpp
+++ b/include/alp/reference/vector.hpp
@@ -424,54 +424,54 @@ namespace alp {
 			/**
 			 * Constructor for a view over another storage-based vector.
 			 *
-			 * @tparam TargetType  The type of the target vector.
+			 * @tparam SourceType  The type of the target vector.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Vector( TargetType &vec_view, ImfR imf_r, ImfC imf_c ) :
-				base_type( vec_view, imf_r, imf_c ) { }
+			Vector( SourceType &source_vector, ImfR imf_r, ImfC imf_c ) :
+				base_type( source_vector, imf_r, imf_c ) { }
 
 			/**
 			 * Constructor for a view over another vector using default IMFs (Identity).
 			 *
-			 * @tparam TargetType  The type of the target vector.
+			 * @tparam SourceType  The type of the target vector.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Vector( TargetType &vec_view ) :
-				base_type( vec_view ) {}
+			Vector( SourceType &source_vector ) :
+				base_type( source_vector ) {}
 
 			/**
 			 * Constructor for a view over another storage-based vector.
 			 *
-			 * @tparam TargetType  The type of the target vector.
+			 * @tparam SourceType  The type of the target vector.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				typename AmfType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_storage< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Vector( TargetType &vec_view, AmfType &&amf ) :
-				base_type( vec_view, std::forward< AmfType >( amf ) ) {}
+			Vector( SourceType &source_vector, AmfType &&amf ) :
+				base_type( source_vector, std::forward< AmfType >( amf ) ) {}
 
 			/**
 			 * Constructor for a functor-based vector that allocates memory.
@@ -493,35 +493,35 @@ namespace alp {
 			/**
 			 * Constructor for a view over another functor-based vector.
 			 *
-			 * @tparam TargetType  The type of the target vector.
+			 * @tparam SourceType  The type of the target vector.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Vector( TargetType &target_vector, ImfR imf_r, ImfC imf_c ) :
+			Vector( SourceType &target_vector, ImfR imf_r, ImfC imf_c ) :
 				base_type( getFunctor( target_vector ), imf_r, imf_c ) {}
 
 			/**
 			 * Constructor for a view over another functor-based vector.
 			 *
-			 * @tparam TargetType  The type of the target vector.
+			 * @tparam SourceType  The type of the target vector.
 			 *
 			 */
 			template<
-				typename TargetType,
+				typename SourceType,
 				std::enable_if_t<
-					std::is_same< TargetType, typename View::applied_to >::value &&
+					std::is_same< SourceType, typename View::applied_to >::value &&
 					internal::is_view_over_functor< View >::value &&
 					!internal::requires_allocation< View >::value
 				> * = nullptr
 			>
-			Vector( TargetType &target_vector ) :
+			Vector( SourceType &target_vector ) :
 				base_type( getFunctor( target_vector ),
 					imf::Id( nrows ( target_vector ) ),
 					imf::Id( 1 )

--- a/include/alp/reference/vector.hpp
+++ b/include/alp/reference/vector.hpp
@@ -439,7 +439,8 @@ namespace alp {
 				base_type( source_vector, imf_r, imf_c ) { }
 
 			/**
-			 * Constructor for a view over another vector using default IMFs (Identity).
+			 * Constructor for a view over another vector applying a view defined
+			 * by View template parameter of the constructed vector.
 			 *
 			 * @tparam SourceType  The type of the target vector.
 			 *
@@ -562,14 +563,11 @@ namespace alp {
 	 *         the created view is non-overlapping with other existing views only when the
 	 *         check can be performed in constant time. 
 	 *
-	 * @tparam T         The vector's elements type
-	 * @tparam Structure The structure of the source and target vector view
-	 * @tparam View      The source's View type
-	 * @tparam backend   The target backend
+	 * @tparam SourceVector  The type of the source ALP vector
 	 *
-	 * @param[in] source The Vector object over which the view is created.
+	 * @param[in] source     The ALP Vector object over which the view is created.
 	 *
-	 * @returns A new vector Vector object.
+	 * @returns A new ALP Vector object.
 	 *
 	 * \parblock
 	 * \par Performance semantics.
@@ -640,10 +638,10 @@ namespace alp {
 	 * 		  The function guarantees the created view is non-overlapping with other existing views only when the
 	 * 		  check can be performed in constant time. 
 	 * 
-	 * @param[in] source The Vector object over which the view is created.
-	 * @param[in] rng 	 A valid range of elements
-	 * 
-	 * @returns          A Vector object.
+	 * @tparam SourceVector  The type of the source ALP vector
+	 *
+	 * @param[in] source     The ALP Vector object over which the view is created.
+	 * @param[in] rng        A valid range of elements
 	 * 
 	 * \parblock
 	 * \par Performance semantics.

--- a/include/alp/type_traits.hpp
+++ b/include/alp/type_traits.hpp
@@ -24,6 +24,8 @@
 #define _H_ALP_TYPE_TRAITS
 
 #include <type_traits>
+#include <alp/backends.hpp>
+#include <alp/density.hpp>
 #include <alp/views.hpp>
 #include <alp/storage.hpp>
 
@@ -346,6 +348,52 @@ namespace alp {
 			std::is_same< view::Functor< typename View::applied_to >, View >::value
 		> {};
 
+	} // namespace internal
+
+	namespace internal {
+		/**
+		 * Defines a new ALP container type form the provided original type
+		 * with the modification of the desired nested template parameter.
+		 */
+		template< typename ContainerType >
+		struct new_container_type_from {};
+
+		template<
+			template< typename, typename, enum Density, typename, typename, typename, enum Backend > typename Container,
+			typename T, typename Structure, enum Density density, typename View, typename ImfR, typename ImfC, enum Backend backend
+		>
+		struct new_container_type_from< Container< T, Structure, density, View, ImfR, ImfC, backend > > {
+
+			typedef Container< T, Structure, density, View, ImfR, ImfC, backend > original_container;
+			static_assert( is_matrix< original_container >::value || is_vector< original_container >::value , "ModifyType supports only ALP Matrix and Vector types." );
+
+			template< typename NewStructure >
+			struct change_structure {
+				typedef Container< T, NewStructure, density, View, ImfR, ImfC, backend > type;
+				typedef new_container_type_from< type > _and_;
+			};
+
+			template< typename NewView >
+			struct change_view {
+				typedef Container< T, Structure, density, NewView, ImfR, ImfC, backend > type;
+				typedef new_container_type_from< type > _and_;
+			};
+
+			template< typename NewImfR >
+			struct change_imfr {
+				typedef Container< T, Structure, density, View, NewImfR, ImfC, backend > type;
+				typedef new_container_type_from< type > _and_;
+			};
+
+			template< typename NewImfC >
+			struct change_imfc {
+				typedef Container< T, Structure, density, View, ImfR, NewImfC, backend > type;
+				typedef new_container_type_from< type > _and_;
+			};
+
+			private:
+				new_container_type_from() = delete;
+		};
 	} // namespace internal
 
 } // namespace alp

--- a/include/alp/type_traits.hpp
+++ b/include/alp/type_traits.hpp
@@ -367,6 +367,12 @@ namespace alp {
 			typedef Container< T, Structure, density, View, ImfR, ImfC, backend > original_container;
 			static_assert( is_matrix< original_container >::value || is_vector< original_container >::value , "ModifyType supports only ALP Matrix and Vector types." );
 
+			template< template< typename, typename, enum Density, typename, typename, typename, enum Backend > typename NewContainer >
+			struct change_container {
+				typedef NewContainer< T, Structure, density, View, ImfR, ImfC, backend > type;
+				typedef new_container_type_from< type > _and_;
+			};
+
 			template< typename NewStructure >
 			struct change_structure {
 				typedef Container< T, NewStructure, density, View, ImfR, ImfC, backend > type;

--- a/include/alp/views.hpp
+++ b/include/alp/views.hpp
@@ -52,7 +52,6 @@ namespace alp {
 			gather,
 			transpose,
 			diagonal,
-			vector,
 			_internal
 		};
 

--- a/include/alp/views.hpp
+++ b/include/alp/views.hpp
@@ -49,6 +49,7 @@ namespace alp {
 		 */
 		enum Views {
 			original,
+			gather,
 			transpose,
 			diagonal,
 			vector,
@@ -61,6 +62,18 @@ namespace alp {
 			using applied_to = OriginalType;
 
 			static constexpr Views type_id = Views::original;
+
+			static std::pair< size_t, size_t > dims( std::pair< size_t, size_t > dims_pair ) {
+				return std::make_pair( dims_pair.first, dims_pair.second );
+			}
+		};
+
+		template< typename OriginalType >
+		struct Gather {
+
+			using applied_to = OriginalType;
+
+			static constexpr Views type_id = Views::gather;
 
 			static std::pair< size_t, size_t > dims( std::pair< size_t, size_t > dims_pair ) {
 				return std::make_pair( dims_pair.first, dims_pair.second );

--- a/include/alp/views.hpp
+++ b/include/alp/views.hpp
@@ -63,9 +63,6 @@ namespace alp {
 
 			static constexpr Views type_id = Views::original;
 
-			static std::pair< size_t, size_t > dims( std::pair< size_t, size_t > dims_pair ) {
-				return std::make_pair( dims_pair.first, dims_pair.second );
-			}
 		};
 
 		template< typename OriginalType >
@@ -75,9 +72,6 @@ namespace alp {
 
 			static constexpr Views type_id = Views::gather;
 
-			static std::pair< size_t, size_t > dims( std::pair< size_t, size_t > dims_pair ) {
-				return std::make_pair( dims_pair.first, dims_pair.second );
-			}
 		};
 
 		template< typename OriginalType >
@@ -87,9 +81,6 @@ namespace alp {
 
 			static constexpr Views type_id = Views::transpose;
 
-			static std::pair< size_t, size_t > dims( std::pair< size_t, size_t > dims_pair ) {
-				return std::make_pair( dims_pair.second, dims_pair.first );
-			}
 		};
 
 		template< typename OriginalType >
@@ -99,9 +90,6 @@ namespace alp {
 
 			static constexpr Views type_id = Views::diagonal;
 
-			static size_t getLength( std::pair< size_t, size_t > dims_pair ) {
-				return std::min( dims_pair.first, dims_pair.second );
-			}
 		};
 
 		template< typename LambdaFunctionType >
@@ -112,9 +100,6 @@ namespace alp {
 			/** Functor views are not exposed to the user */
 			static constexpr Views type_id = Views::_internal;
 
-			static std::pair< size_t, size_t > getLength( std::pair< size_t, size_t > dims_pair ) {
-				return std::make_pair( dims_pair.first, dims_pair.second );
-			}
 		};
 
 	}; // namespace view

--- a/include/alp/views.hpp
+++ b/include/alp/views.hpp
@@ -51,6 +51,7 @@ namespace alp {
 			original,
 			transpose,
 			diagonal,
+			vector,
 			_internal
 		};
 


### PR DESCRIPTION
Move all AMFFactory invokations to Matrix constructors
Add type trait that defines new container types with a possibility to modify a single template parameter.
Add vector view type used for gather view on a matrix when one dimension is of size 1 (returning a vector)
Remove redundant get_view implementations