### PR TITLE
533 out of place set does not clear the output vector

### DIFF
--- a/include/graphblas/algorithms/label.hpp
+++ b/include/graphblas/algorithms/label.hpp
@@ -275,11 +275,13 @@ namespace grb {
 					std::swap( out, f );
 					return SUCCESS;
 				}
-			} else {
-				std::cerr << "Info: label propagation exiting with " << toString(ret) << "\n";
 			}
 
 			// done
+			if( s == 0 ) {
+				std::cerr << "Warning: label propagation exiting with " << toString(ret)
+					<< "\n";
+			}
 			return ret;
 		}
 

--- a/include/graphblas/algorithms/label.hpp
+++ b/include/graphblas/algorithms/label.hpp
@@ -116,7 +116,8 @@ namespace grb {
 		 *     accelerating the PageRank computation', ACM Press, 2003.
 		 */
 		template< typename IOType >
-		RC label( Vector< IOType > &out,
+		RC label(
+			Vector< IOType > &out,
 			const Vector< IOType > &y, const Matrix< IOType > &W,
 			const size_t n, const size_t l,
 			const size_t MaxIterations = 1000
@@ -230,7 +231,12 @@ namespace grb {
 					<< "nnz( mask ) = " << nnz( mask ) << "\n";
 #endif
 				// clamps the first l labelled nodes
-				ret = ret ? ret : set( fNext, mask, f );
+				ret = ret ? ret : foldl(
+					fNext, mask,
+					f,
+					grb::operators::right_assign< IOType >()
+				);
+				assert( ret == SUCCESS );
 #ifdef _DEBUG
 				std::cerr << "\t post-set nnz( fNext ) = " << nnz( fNext ) << "\n";
 				printVector(
@@ -246,28 +252,31 @@ namespace grb {
 #ifdef _DEBUG
 				std::cerr << "\t pre-set  nnz(f) = " << nnz( f ) << "\n";
 #endif
-				ret = ret ? ret : set( f, fNext );
+				std::swap( f, fNext );
 #ifdef _DEBUG
 				std::cerr << "\t post-set nnz(f) = " << nnz( f ) << "\n";
 #endif
 				// go to next iteration
-				(void)++iter;
+				(void) ++iter;
 			}
 
 			if( ret == SUCCESS ) {
 				if( different ) {
 					if( s == 0 ) {
-						std::cout << "Warning: label propagation did not converge after "
+						std::cerr << "Info: label propagation did not converge after "
 							<< (iter-1) << " iterations\n";
 					}
 					return FAILED;
 				} else {
 					if( s == 0 ) {
-						std::cout << "Info: label propagation converged in "
+						std::cerr << "Info: label propagation converged in "
 							<< (iter-1) << " iterations\n";
 					}
-					return set( out, f );
+					std::swap( out, f );
+					return SUCCESS;
 				}
+			} else {
+				std::cerr << "Info: label propagation exiting with " << toString(ret) << "\n";
 			}
 
 			// done

--- a/include/graphblas/descriptors.hpp
+++ b/include/graphblas/descriptors.hpp
@@ -117,11 +117,11 @@ namespace grb {
 		static constexpr Descriptor structural_complement = structural | invert_mask;
 
 		/**
-		 * Indicates that all input vectors to an ALP/GraphBLAS primitive are
-		 * structurally dense.
+		 * Indicates that all input and output vectors to an ALP/GraphBLAS primitive
+		 * are structurally dense.
 		 *
-		 * If a user passes this descriptor but one or more vectors input to the call
-		 * are \em not structurally dense, then #ILLEGAL shall be returned.
+		 * If a user passes this descriptor but one or more vectors to the call are
+		 * \em not structurally dense, then #ILLEGAL shall be returned.
 		 *
 		 * \warning <em>All vectors</em> includes any vectors that operate as masks.
 		 *          Thus if the primitive is to operate with structurally sparse masks
@@ -134,6 +134,10 @@ namespace grb {
 		 *          passing this descriptor to such primitive indicates that also the
 		 *          output vector is structurally dense.
 		 *
+		 * \warning For out-of-place operations with vector output(s), passing this
+		 *          descriptor also demands that the output vectors are already
+		 *          dense.
+		 *
 		 * \warning Vectors with explicit zeroes (under the semiring passed to the
 		 *          related primitive) will be computed with explicitly.
 		 *
@@ -141,6 +145,7 @@ namespace grb {
 		 *   1) less run-time overhead as code handling sparsity is disabled;
 		 *   2) smaller binary sizes as code handling structurally sparse vectors is
 		 *      not emitted (unless required elsewhere).
+		 *
 		 * The consistent use of this descriptor is hence strongly encouraged.
 		 */
 		static constexpr Descriptor dense = 16;

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -1849,6 +1849,12 @@ namespace grb {
 			return MISMATCH;
 		}
 
+		const size_t n = size( x );
+
+		if( descr & descriptors::dense ) {
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
+		}
+
 #ifdef _DEBUG
 		std::cout << "In foldr ([T]<-[T])\n";
 #endif
@@ -1915,6 +1921,10 @@ namespace grb {
 		const size_t n = size( x );
 		if( n != size( y ) || n != size( m ) ) {
 			return MISMATCH;
+		}
+		if( descr & descriptors::dense ) {
+			if( size( m ) > 0 && nnz( m ) != n ) { return ILLEGAL; }
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
 		}
 
 		if( nnz( x ) < n || nnz( y ) < n ) {
@@ -2033,6 +2043,9 @@ namespace grb {
 		if( n != size( y ) ) {
 			return MISMATCH;
 		}
+		if( descr & descriptors::dense ) {
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
+		}
 
 		const Vector< bool, reference, Coords > * const null_mask = nullptr;
 		if( nnz( x ) < n || nnz( y ) < n ) {
@@ -2097,6 +2110,10 @@ namespace grb {
 		const size_t n = size( x );
 		if( n != size( y ) || n != size( m ) ) {
 			return MISMATCH;
+		}
+		if( descr & descriptors::dense ) {
+			if( size( m ) > 0 && nnz( m ) != n ) { return ILLEGAL; }
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
 		}
 
 		if( nnz( x ) < n || nnz( y ) < n ) {
@@ -2577,6 +2594,9 @@ namespace grb {
 		if( n != size( y ) ) {
 			return MISMATCH;
 		}
+		if( descr & descriptors::dense ) {
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
+		}
 
 		// all OK, execute
 		const Vector< bool, reference, Coords > * const null_mask = nullptr;
@@ -2700,6 +2720,9 @@ namespace grb {
 		if( n != size( y ) ) {
 			return MISMATCH;
 		}
+		if( descr & descriptors::dense ) {
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
+		}
 
 		// all OK, execute
 		const Vector< bool, reference, Coords > * const null_mask = nullptr;
@@ -2768,6 +2791,10 @@ namespace grb {
 		if( n != size( y ) || n != size( m ) ) {
 			return MISMATCH;
 		}
+		if( descr & descriptors::dense ) {
+			if( size( m ) > 0 && nnz( m ) != n ) { return ILLEGAL; }
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
+		}
 
 		// all OK, execute
 		if( nnz( x ) < n || nnz( y ) < n ) {
@@ -2834,6 +2861,10 @@ namespace grb {
 		const size_t n = size( x );
 		if( n != size( y ) || n != size( m ) ) {
 			return MISMATCH;
+		}
+		if( descr & descriptors::dense ) {
+			if( size( m ) > 0 && nnz( m ) != n ) { return ILLEGAL; }
+			if( nnz( x ) != n || nnz( y ) != n ) { return ILLEGAL; }
 		}
 
 		// all OK, execute

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -1058,9 +1058,6 @@ namespace grb {
 			if( !sparse && nnz( to_fold ) < n ) {
 				return ILLEGAL;
 			}
-			if( masked && !sparse && nnz( *m ) < n ) {
-				return ILLEGAL;
-			}
 			if( phase == RESIZE ) {
 				return SUCCESS;
 			}

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -674,7 +674,7 @@ namespace grb {
 			return ILLEGAL;
 		}
 		if( descr & descriptors::dense ) {
-			if( nnz( y ) < size( y ) ) {
+			if( nnz( y ) < size( y ) || nnz( x ) < size( x ) ) {
 				return ILLEGAL;
 			}
 		}
@@ -822,7 +822,10 @@ namespace grb {
 			return ILLEGAL;
 		}
 		if( descr & descriptors::dense ) {
-			if( nnz( y ) < grb::size( y ) || nnz( mask ) < grb::size( mask ) ) {
+			if( nnz( x ) < grb::size( x ) ||
+				nnz( y ) < grb::size( y ) ||
+				nnz( mask ) < grb::size( mask )
+			) {
 				return ILLEGAL;
 			}
 		}

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -484,6 +484,11 @@ namespace grb {
 		const auto & m_coors = internal::getCoordinates( m );
 		auto m_p = internal::getRaw( m );
 
+		// make the vector empty unless the dense descriptor is provided
+		if( !( descr & descriptors::dense ) ) {
+			internal::getCoordinates( x ).clear();
+		}
+
 #ifdef _H_GRB_REFERENCE_OMP_IO
 		#pragma omp parallel
 		{
@@ -658,6 +663,11 @@ namespace grb {
 		OutputType * __restrict__ const dst = internal::getRaw( x );
 		const InputType * __restrict__ const src = internal::getRaw( y );
 
+		// make the vector empty unless the dense descriptor is provided
+		if( !( descr & descriptors::dense ) ) {
+			internal::getCoordinates( x ).clear();
+		}
+
 		// get #nonzeroes
 		const size_t nz = internal::getCoordinates( y ).nonzeroes();
 #ifdef _DEBUG
@@ -812,6 +822,11 @@ namespace grb {
 		const auto &m_coors = internal::getCoordinates( mask );
 		const auto &y_coors = internal::getCoordinates( y );
 		auto &x_coors = internal::getCoordinates( x );
+
+		// make the vector empty unless the dense descriptor is provided
+		if( !( descr & descriptors::dense ) ) {
+			internal::getCoordinates( x ).clear();
+		}
 
 		// choose optimal loop size
 		const bool loop_over_y = (descr & descriptors::invert_mask) ||

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -367,7 +367,8 @@ namespace grb {
 		typename Coords
 	>
 	RC set(
-		Vector< DataType, reference, Coords > &x, const T val,
+		Vector< DataType, reference, Coords > &x,
+		const T val,
 		const Phase &phase = EXECUTE,
 		const typename std::enable_if<
 			!grb::is_object< DataType >::value &&
@@ -381,6 +382,12 @@ namespace grb {
 			"called with a value type that does not match that of the given vector"
 		);
 
+		// dynamic checks
+		const size_t n = size( x );
+		if( (descr & descriptors::dense) && nnz( x ) < n ) {
+			return ILLEGAL;
+		}
+
 		if( phase == RESIZE ) {
 			return SUCCESS;
 		}
@@ -390,9 +397,10 @@ namespace grb {
 		const DataType toCopy = static_cast< DataType >( val );
 
 		// make vector dense if it was not already
-		internal::getCoordinates( x ).assignAll();
+		if( !(descr & descriptors::dense) ) {
+			internal::getCoordinates( x ).assignAll();
+		}
 		DataType * const raw = internal::getRaw( x );
-		const size_t n = internal::getCoordinates( x ).size();
 
 #ifdef _H_GRB_REFERENCE_OMP_IO
 		#pragma omp parallel
@@ -460,34 +468,47 @@ namespace grb {
 			"vector"
 		);
 
+		// catch empty mask
+		if( size( m ) == 0 ) {
+			return set< descr >( x, val, phase );
+		}
+
+		// dynamic sanity checks
+		const size_t sizex = size( x );
+		if( sizex != size( m ) ) {
+			return MISMATCH;
+		}
+		if( (descr & descriptors::dense) &&
+			(nnz( x ) < sizex || nnz( m ) < sizex)
+		) {
+			return ILLEGAL;
+		}
+
+		// handle trivial resize
 		if( phase == RESIZE ) {
 			return SUCCESS;
 		}
 		assert( phase == EXECUTE );
 
-		// catch empty mask
-		if( size( m ) == 0 ) {
-			return set< descr >( x, val );
-		}
-
-		// dynamic sanity checks
-		if( size( x ) != size( m ) ) {
-			return MISMATCH;
-		}
-
-		// pre-cast value to be copied
-		const DataType toCopy = static_cast< DataType >( val );
-
-		// make vector dense if it was not already
-		DataType * const raw = internal::getRaw( x );
-		auto & coors = internal::getCoordinates( x );
-		const auto & m_coors = internal::getCoordinates( m );
-		auto m_p = internal::getRaw( m );
-
 		// make the vector empty unless the dense descriptor is provided
-		if( !( descr & descriptors::dense ) ) {
+		const bool mask_is_dense = (descr & descriptors::structural) &&
+			!(descr & descriptors::invert_mask) && (
+				(descr & descriptors::dense) ||
+				nnz( m ) == sizex
+			);
+		if( !((descr & descriptors::dense) && mask_is_dense) ) {
 			internal::getCoordinates( x ).clear();
+		} else if( mask_is_dense ) {
+			// dispatch to faster variant if mask is structurally dense
+			return set< descr >( x, val, phase );
 		}
+
+		// pre-cast value to be copied and get coordinate handles
+		const DataType toCopy = static_cast< DataType >( val );
+		DataType * const raw = internal::getRaw( x );
+		auto &coors = internal::getCoordinates( x );
+		const auto &m_coors = internal::getCoordinates( m );
+		const MaskType * const m_p = internal::getRaw( m );
 
 #ifdef _H_GRB_REFERENCE_OMP_IO
 		#pragma omp parallel
@@ -520,18 +541,20 @@ namespace grb {
 				}
 #ifdef _H_GRB_REFERENCE_OMP_IO
 				if( !coors.asyncAssign( index, localUpdate ) ) {
-					(void)++asyncAssigns;
+					(void) ++asyncAssigns;
 				}
 				if( asyncAssigns == maxAsyncAssigns ) {
-					(void)coors.joinUpdate( localUpdate );
+					(void) coors.joinUpdate( localUpdate );
 					asyncAssigns = 0;
 				}
 #else
-				(void)coors.assign( index );
+				(void) coors.assign( index );
 #endif
-				raw[ index ] =
-					internal::ValueOrIndex< descr, DataType, DataType >::getFromScalar(
-						toCopy, index );
+				raw[ index ] = internal::ValueOrIndex<
+						descr, DataType, DataType
+					>::getFromScalar(
+						toCopy, index
+					);
 			}
 #ifdef _H_GRB_REFERENCE_OMP_IO
 			while( !coors.joinUpdate( localUpdate ) ) {}
@@ -570,21 +593,26 @@ namespace grb {
 	) {
 		// static sanity checks
 		NO_CAST_ASSERT( ( !(descr & descriptors::no_casting) ||
-			std::is_same< DataType, T >::value ), "grb::set (Vector, at index)",
+				std::is_same< DataType, T >::value ),
+			"grb::set (Vector, at index)",
 			"called with a value type that does not match that of the given "
-			"vector" );
+			"vector"
+		);
 		if( phase == RESIZE ) {
 			return SUCCESS;
 		}
 		assert( phase == EXECUTE );
 
 		// dynamic sanity checks
-		if( i >= internal::getCoordinates( x ).size() ) {
+		if( i >= size( x ) ) {
 			return MISMATCH;
+		}
+		if( (descr & descriptors::dense) && nnz( x ) < size( x ) ) {
+			return ILLEGAL;
 		}
 
 		// do set
-		(void)internal::getCoordinates( x ).assign( i );
+		(void) internal::getCoordinates( x ).assign( i );
 		internal::getRaw( x )[ i ] = static_cast< DataType >( val );
 
 #ifdef _DEBUG
@@ -622,16 +650,16 @@ namespace grb {
 	) {
 		// static sanity checks
 		NO_CAST_ASSERT( ( !(descr & descriptors::no_casting) ||
-			std::is_same< OutputType, InputType >::value ),
+				std::is_same< OutputType, InputType >::value ),
 			"grb::copy (Vector)",
 			"called with vector parameters whose element data types do not match"
 		);
 		constexpr bool out_is_void = std::is_void< OutputType >::value;
 		constexpr bool in_is_void = std::is_void< OutputType >::value;
-		static_assert( ! in_is_void || out_is_void,
+		static_assert( !in_is_void || out_is_void,
 			"grb::set (reference, vector <- vector, masked): "
 			"if input is void, then the output must be also" );
-		static_assert( ! ( descr & descriptors::use_index ) || ! out_is_void,
+		static_assert( !(descr & descriptors::use_index) || !out_is_void,
 			"grb::set (reference, vector <- vector, masked): "
 			"use_index descriptor cannot be set if output vector is void" );
 
@@ -664,7 +692,7 @@ namespace grb {
 		const InputType * __restrict__ const src = internal::getRaw( y );
 
 		// make the vector empty unless the dense descriptor is provided
-		if( !( descr & descriptors::dense ) ) {
+		if( !(descr & descriptors::dense) ) {
 			internal::getCoordinates( x ).clear();
 		}
 
@@ -824,7 +852,12 @@ namespace grb {
 		auto &x_coors = internal::getCoordinates( x );
 
 		// make the vector empty unless the dense descriptor is provided
-		if( !( descr & descriptors::dense ) ) {
+		const bool mask_is_dense = (descr & descriptors::structural) &&
+			!(descr & descriptors::invert_mask) && (
+				(descr && descriptors::dense) ||
+				nnz( mask ) == grb::size( mask )
+			);
+		if( !((descr & descriptors::dense) && mask_is_dense) ) {
 			internal::getCoordinates( x ).clear();
 		}
 

--- a/tests/smoke/label.cpp
+++ b/tests/smoke/label.cpp
@@ -41,7 +41,10 @@ using namespace grb;
 constexpr size_t MaxPrinting = 10;
 
 // forward declaration of the graph dataset parser
-bool readEdges( std::string filename, bool use_indirect, size_t * n, size_t * nz, size_t ** I, size_t ** J, double ** weights );
+bool readEdges(
+	std::string filename, bool use_indirect,
+	size_t * n, size_t * nz, size_t ** I, size_t ** J, double ** weights
+);
 
 struct input {
 	char filename[ 1024 ];
@@ -186,10 +189,9 @@ int main( int argc, char ** argv ) {
 
 	// sanity check
 	if( argc < 3 || argc > 5 ) {
-		std::cout << "Usage: " << argv[ 0 ]
-				  << " <dataset> <direct/indirect> (number of inner "
-					 "iterations) (number of outer iterations)"
-				  << std::endl;
+		std::cout << "Usage: " << argv[ 0 ] << " <dataset> <direct/indirect> "
+			<< "(number of inner iterations) (number of outer iterations)"
+			<< std::endl;
 		return 0;
 	}
 	std::cout << "Test executable: " << argv[ 0 ] << std::endl;
@@ -200,7 +202,7 @@ int main( int argc, char ** argv ) {
 		std::cerr << "Could not parse filename: too long." << std::endl;
 		return 10;
 	}
-	(void)strncpy( in.filename, argv[ 1 ], 1023 );
+	(void) strncpy( in.filename, argv[ 1 ], 1023 );
 	in.filename[ 1023 ] = '\0';
 	if( strncmp( argv[ 2 ], "direct", 6 ) == 0 ) {
 		in.direct = true;
@@ -217,23 +219,24 @@ int main( int argc, char ** argv ) {
 	if( argc >= 4 ) {
 		inner = strtoumax( argv[ 3 ], &end, 10 );
 		if( argv[ 3 ] == end ) {
-			std::cerr << "Could not parse argument for number of inner "
-						 "repititions."
-					  << std::endl;
+			std::cerr << "Could not parse argument for number of inner repititions."
+				<< std::endl;
 			return 30;
 		}
 	}
 	if( argc >= 5 ) {
 		outer = strtoumax( argv[ 4 ], &end, 10 );
 		if( argv[ 4 ] == end ) {
-			std::cerr << "Could not parse argument for number of outer "
-						 "repititions."
-					  << std::endl;
+			std::cerr << "Could not parse argument for number of outer repititions."
+				<< std::endl;
 			return 40;
 		}
 	}
 
-	std::cout << "Executable called with parameters filename " << in.filename << ", direct = " << in.direct << ", and #vertices = " << in.n << std::endl;
+	std::cout << "Executable called with parameters "
+		<< "filename " << in.filename << ", "
+		<< "direct = " << in.direct << ", and "
+		<< "#vertices = " << in.n << std::endl;
 
 	// the output struct
 	struct output out;
@@ -242,7 +245,8 @@ int main( int argc, char ** argv ) {
 
 	enum grb::RC rc = launcher.exec( &grbProgram, in, out, inner, outer, true );
 	if( rc != SUCCESS ) {
-		std::cerr << "launcher.exec returns with non-SUCCESS error code " << (int)rc << std::endl;
+		std::cerr << "launcher.exec returns with non-SUCCESS error code "
+			<< toString(rc) << std::endl;
 		return 50;
 	}
 
@@ -250,9 +254,10 @@ int main( int argc, char ** argv ) {
 
 	// done
 	if( out.error_code != SUCCESS ) {
-		std::cout << "Test FAILED.\n\n";
+		std::cout << "Test FAILED\n\n";
 		return 255;
 	}
-	std::cout << "Test OK.\n\n";
+	std::cout << "Test OK\n\n";
 	return 0;
 }
+

--- a/tests/smoke/label_test.cpp
+++ b/tests/smoke/label_test.cpp
@@ -34,6 +34,7 @@
 
 #include "graphblas.hpp"
 
+
 using namespace grb;
 
 static size_t n;  // total number of vertices
@@ -62,13 +63,15 @@ using namespace grb;
 bool init_input( const struct input & data_in ) {
 	// a binary tree with data_in.n vertices at the leaves
 	n = 2 * data_in.n - 1;
-	// construct the input labels: the first l (leaves) are clamped to 1 and the rest are 0
+	// construct the input labels: the first l (leaves) are clamped to 1 and the
+	// rest are 0
 	l = data_in.n;
 	labels = new double[ n ];
 	for( size_t i = 0; i < n; i++ )
 		labels[ i ] = ( i < l ) ? 1 : 0;
 
-	// there are n-1 edges in the tree and so 2(n-1) in the matrix, since it's a symmetric
+	// there are n-1 edges in the tree and so 2(n-1) in the matrix, since it's
+	// symmetric
 	nz = 2 * ( n - 1 );
 	weights = new double[ nz ];
 	I = new size_t[ nz ];
@@ -82,13 +85,11 @@ bool init_input( const struct input & data_in ) {
 		size_t dst = ( e & ~0x01 ) + pow( 2.0, ( levels - level ) ) - floor( edge / 2 );
 		I[ e ] = e;
 		J[ e ] = dst;
-		// std::cout << "e " << e << " level " << level << " edge " << edge << " edges " << edges << " I " << I[e] << " J " << J[e] << std::endl;
 		weights[ e ] = 1.0;
 		size_t e_other = e + ( nz / 2 );
 		I[ e_other ] = dst;
 		J[ e_other ] = e;
 		weights[ e_other ] = 1.0;
-		// std::cout << "e other " << e_other << " level " << level << " edge " << edge << " edges " << edges << " I " << I[e_other] << " J " << J[e_other] << std::endl;
 		edge++;
 		// update counters when we come to the end of the current tree level
 		if( edge == edges ) {
@@ -110,12 +111,14 @@ void free_input() {
 }
 
 // main label propagation algorithm
-void grbProgram( const struct input & data_in, struct output & out ) {
+void grbProgram( const struct input &data_in, struct output &out ) {
 
 	grb::utils::Timer timer;
 	timer.reset();
 	const size_t s = spmd<>::pid();
-	(void)s;
+#ifdef NDEBUG
+	(void) s;
+#endif
 	assert( s < spmd<>::nprocs() );
 
 	// get input n
@@ -129,12 +132,15 @@ void grbProgram( const struct input & data_in, struct output & out ) {
 	// create the intial set of l input labels in the vector y
 	Vector< double > y( n );
 	Vector< double > f( n );
-	buildVector( y, &( labels[ 0 ] ), &( labels[ 0 ] ) + n, SEQUENTIAL );
+	buildVector( y, &(labels[ 0 ]), &(labels[ 0 ]) + n, SEQUENTIAL );
 
 	// create the symmetric weight matrix W, representing the weighted graph
 	Matrix< double > W( n, n );
 	resize( W, nz );
-	RC rc = buildMatrixUnique( W, &( I[ 0 ] ), &( J[ 0 ] ), &( weights[ 0 ] ), nz, SEQUENTIAL );
+	RC rc = buildMatrixUnique(
+		W, &(I[ 0 ]), &(J[ 0 ]), &(weights[ 0 ]), nz,
+		SEQUENTIAL
+	);
 	if( rc != SUCCESS ) {
 		out.error_code = ILLEGAL;
 		free_input();
@@ -156,10 +162,9 @@ void grbProgram( const struct input & data_in, struct output & out ) {
 int main( int argc, char ** argv ) {
 	// sanity check
 	if( argc < 2 || argc > 4 ) {
-		std::cout << "Usage: " << argv[ 0 ]
-				  << " <number of vertices> (number of inner iterations) "
-					 "(number of outer iterations)"
-				  << std::endl;
+		std::cout << "Usage: " << argv[ 0 ] << " <number of vertices> "
+			<< "(number of inner iterations) (number of outer iterations)"
+			<< std::endl;
 		return 0;
 	}
 	std::cout << "Test executable: " << argv[ 0 ] << std::endl;
@@ -167,7 +172,7 @@ int main( int argc, char ** argv ) {
 	// the input struct
 	struct input in;
 	in.n = atoi( argv[ 1 ] );
-	std::cout << "Executable called with parameters #vertices = " << in.n << std::endl;
+	std::cout << "Executable called with parameters #vertices = " << in.n << "\n";
 
 	// the output struct
 	struct output out;
@@ -176,17 +181,19 @@ int main( int argc, char ** argv ) {
 
 	enum grb::RC rc = launcher.exec( &grbProgram, in, out );
 	if( rc != SUCCESS ) {
-		std::cerr << "launcher.exec returns with non-SUCCESS error code " << (int)rc << std::endl;
+		std::cerr << "launcher.exec returns with non-SUCCESS error code "
+			<< toString(rc) << std::endl;
 		return 50;
 	}
 
-	std::cout << "Error code is " << out.error_code << ".\n";
+	std::cout << "Error code is " << toString(out.error_code) << "\n";
 
 	// done
 	if( out.error_code != SUCCESS ) {
-		std::cout << "Test FAILED.\n\n";
+		std::cout << "Test FAILED\n\n";
 		return 1;
 	}
-	std::cout << "Test OK.\n\n";
+	std::cout << "Test OK\n\n";
 	return 0;
 }
+

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -202,7 +202,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			if [ -f ${TEST_DATA_DIR}/${TESTNAME}.mtx ]; then
 				n=$(grep -v '^%' ${TEST_DATA_DIR}/${TESTNAME}.mtx | head -1 | awk '{print $1}' )
 				m=$(grep -v '^%' ${TEST_DATA_DIR}/${TESTNAME}.mtx | head -1 | awk '{print $2}' )
-				echo ">>>      [x]           [ ]       Testing the conjugate gradient complex  algorithm for the input"
+				echo ">>>      [x]           [ ]       Testing the conjugate gradient complex algorithm for the input"
 				echo "                                 matrix (${n}x${m}) taken from ${TESTNAME}.mtx. This test"
 				echo "                                 verifies against a ground-truth solution vector. The test"
 				echo "                                 employs the grb::Launcher in automatic mode. It uses"

--- a/tests/unit/set.cpp
+++ b/tests/unit/set.cpp
@@ -23,6 +23,295 @@
 
 using namespace grb;
 
+static grb::RC dense_tests(
+	grb::Vector< double > &dst,
+	grb::Vector< double > &src
+) {
+	assert( size( dst ) == size( src ) );
+	grb::Vector< bool > full_mask( size( dst ) ), one_mask( size( dst ) );
+	grb::RC ret = grb::set( full_mask, false );
+	ret = ret ? ret : grb::setElement( one_mask, false, size( dst ) / 2 );
+	ret = ret ? ret : grb::clear( src );
+	ret = ret ? ret : grb::clear( dst );
+	if( ret != SUCCESS ) {
+		std::cerr << "\t initalisation of dense tests FAILED\n";
+		return ret;
+	}
+
+	std::cerr << "\t dense subtest 1:";
+	ret = grb::setElement< descriptors::dense >( src, 3.14, 0 );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 2:";
+	ret = grb::set< descriptors::dense >( dst, 1.0 );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 3:";
+	ret = grb::set< descriptors::dense >( dst, one_mask, 1.0 );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 4:";
+	ret = grb::set< descriptors::dense >( dst, full_mask, 1.0 );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 5:";
+	ret = grb::set< descriptors::dense >( dst, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 6:";
+	ret = grb::set< descriptors::dense >( dst, one_mask, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 7:";
+	ret = grb::set< descriptors::dense >( dst, full_mask, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 8:";
+	ret = grb::set( src, 3.14 );
+	ret = ret ? ret : grb::set< descriptors::dense >( dst, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 9:";
+	ret = grb::set< descriptors::dense >( dst, one_mask, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 10:";
+	ret = grb::set< descriptors::dense >( dst, full_mask, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		return FAILED;
+	}
+
+	std::cerr << "\b 11:";
+	ret = grb::set( dst, 0 );
+	ret = ret ? ret : grb::set< descriptors::dense >( dst, 1.0 );
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 1.0 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected 1\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 12:";
+	ret = grb::set( dst, 0 );
+	ret = ret ? ret : grb::set< descriptors::dense >( dst, one_mask, 1.0 );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	ret = SUCCESS;
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 0.0 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected 0\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 13:";
+	ret = grb::set< descriptors::dense >( dst, full_mask, 1.0 );
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+			<< "expected no entries\n";
+		ret = FAILED;
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 14:";
+	ret = grb::set( dst, 0 );
+	ret = ret ? ret : grb::set< descriptors::dense | descriptors::invert_mask >(
+		dst, full_mask, 1.0
+	);
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 1.0 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected entry with value 1\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 15:";
+	ret = grb::set< descriptors::dense >( dst, src );
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 3.14 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected 3.14\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 16:";
+	ret = grb::set( dst, 0 );
+	ret = ret ? ret : grb::set< descriptors::dense >( dst, one_mask, src );
+	if( ret != ILLEGAL ) {
+		std::cerr << " expected ILLEGAL, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	ret = SUCCESS;
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 0 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected zero values\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 17:";
+	ret = grb::set< descriptors::dense >( dst, full_mask, src );
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != 0 ) {
+		std::cerr << " expected 0, got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+			<< "expected no entries\n";
+		ret = FAILED;
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b 18:";
+	ret = grb::set( dst, 0 );
+	ret = ret ? ret : grb::set< descriptors::dense | descriptors::invert_mask >(
+		dst, full_mask, src
+	);
+	if( ret != SUCCESS ) {
+		std::cerr << " expected SUCCESS, got " << toString( ret ) << "\n";
+		return FAILED;
+	}
+	if( nnz( dst ) != size( dst ) ) {
+		std::cerr << " expected " << size( dst ) << ", got " << nnz( dst ) << "\n";
+		ret = FAILED;
+	}
+	for( const auto &pair : dst ) {
+		if( pair.second != 3.14 ) {
+			std::cerr << "\t got ( " << pair.first << ", " << pair.second << " ), "
+				<< "expected 3.14\n";
+			ret = FAILED;
+		}
+	}
+	if( ret != SUCCESS ) { return ret; }
+
+	std::cerr << "\b OK\n";
+	return SUCCESS;
+}
+
 void grb_program( const size_t &n, grb::RC &rc ) {
 	grb::Vector< double > dst( n ), src( n );
 
@@ -373,6 +662,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		return;
 	}
 
+	// test set-to-clear
 	rc = grb::clear( src );
 	if( rc == SUCCESS ) {
 		rc = grb::set( dst, src );
@@ -393,6 +683,28 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 			rc = FAILED;
 		}
 	}
+
+	// test double-set-to-clear
+	rc = grb::set( dst, src );
+	if( rc != SUCCESS ) {
+		std::cerr << "\t Set to empty vector FAILED with error code "
+			<< grb::toString( rc ) << "\n";
+	} else {
+		if( nnz( dst ) != 0 ) {
+			std::cerr << "\t (set-to-empty) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 0.\n";
+			rc = FAILED;
+		}
+		for( const auto &pair : dst ) {
+			std::cerr << "\t (set-to-empty) unexpected entry "
+				<< "( " << pair.first << ", " << pair.second << " ), "
+				<< "this position should have been empty\n";
+			rc = FAILED;
+		}
+	}
+
+	// test behaviour under dense descriptor
+	rc = dense_tests( dst, src );
 
 	// done
 	return;

--- a/tests/unit/set.cpp
+++ b/tests/unit/set.cpp
@@ -22,7 +22,7 @@
 
 using namespace grb;
 
-void grb_program( const size_t & n, grb::RC & rc ) {
+void grb_program( const size_t &n, grb::RC &rc ) {
 	grb::Vector< double > dst( n ), src( n );
 
 	// test set
@@ -31,12 +31,15 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		std::cerr << "\tset-to-value FAILED\n";
 	} else {
 		if( nnz( src ) != n ) {
-			std::cerr << "\t (set-to-value) unexpected number of nonzeroes " << nnz( src ) << ", expected " << n << "\n";
+			std::cerr << "\t (set-to-value) unexpected number of nonzeroes "
+				<< nnz( src ) << ", expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : src ) {
+		for( const auto &pair : src ) {
 			if( pair.second != 1.5 ) {
-				std::cerr << "\t (set-to-value) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected value 1.5.\n";
+				std::cerr << "\t (set-to-value) unexpected entry "
+					<< ( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5.\n";
 				rc = FAILED;
 			}
 		}
@@ -51,12 +54,15 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		std::cerr << "\tset-to-index FAILED\n";
 	} else {
 		if( nnz( dst ) != n ) {
-			std::cerr << "\t (set-to-index) unexpected number of nonzeroes " << nnz( dst ) << ", expected " << n << "\n";
+			std::cerr << "\t (set-to-index) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.second != pair.first ) {
-				std::cerr << "\t (set-to-index) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected value " << static_cast< double >( pair.first ) << ".\n";
+				std::cerr << "\t (set-to-index) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value " << static_cast< double >( pair.first ) << ".\n";
 				rc = FAILED;
 			}
 		}
@@ -68,15 +74,19 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 	// test set overwrite
 	rc = grb::set( dst, src );
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Set-overwrite FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Set-overwrite FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != n ) {
-			std::cerr << "\t (set-overwrite) unexpected number of nonzeroes " << nnz( dst ) << ", expected " << n << "\n";
+			std::cerr << "\t (set-overwrite) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.second != 1.5 ) {
-				std::cerr << "\t (set-overwrite) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected value 1.5\n";
+				std::cerr << "\t (set-overwrite) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5\n";
 				rc = FAILED;
 			}
 		}
@@ -91,15 +101,19 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		rc = grb::set( dst, src );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Set-into-cleared FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Set-into-cleared FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != n ) {
-			std::cerr << "\t (set-into-cleared) unexpected number of nonzeroes " << nnz( dst ) << ", expected " << n << "\n";
+			std::cerr << "\t (set-into-cleared) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.second != 1.5 ) {
-				std::cerr << "\t (set-into-cleared) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected value 1.5\n";
+				std::cerr << "\t (set-into-cleared) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5\n";
 				rc = FAILED;
 			}
 		}
@@ -117,19 +131,25 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		rc = grb::set( dst, src, src );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Masked-set FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Masked-set FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != n - 1 ) {
-			std::cerr << "\t (masked-set) unexpected number of nonzeroes " << nnz( dst ) << ", expected " << ( n - 1 ) << "\n";
+			std::cerr << "\t (masked-set) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected " << ( n - 1 ) << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.first != n / 2 && pair.second != 1.5 ) {
-				std::cerr << "\t (masked-set) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected value 1.5\n";
+				std::cerr << "\t (masked-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5\n";
 				rc = FAILED;
 			}
 			if( pair.first == n / 2 ) {
-				std::cerr << "\t (masked-set) unexpected entry ( " << pair.first << ", " << pair.second << " ), expected no entry at this position\n";
+				std::cerr << "\t (masked-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -144,21 +164,25 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		rc = grb::set< grb::descriptors::invert_mask >( dst, src, src );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Inverted-mask set FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Inverted-mask set FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 1 ) {
-			std::cerr << "\t (inverted-mask-set) unexpected number of "
-						 "nonzeroes "
-					  << nnz( dst ) << ", expected 1.\n";
+			std::cerr << "\t (inverted-mask-set) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.first == n / 2 && pair.second != 0 ) {
-				std::cerr << "\t (inverted-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << ": expected value 0\n";
+				std::cerr << "\t (inverted-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 0\n";
 				rc = FAILED;
 			}
 			if( pair.first != n / 2 ) {
-				std::cerr << "\t (inverted-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected no entry at this position\n";
+				std::cerr << "\t (inverted-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -166,6 +190,8 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 	if( rc != SUCCESS ) {
 		return;
 	}
+
+	// TODO continue code review from here. Also check if there is a set-to-empty test
 
 	// test sparse mask set
 	rc = grb::clear( dst );

--- a/tests/unit/set.cpp
+++ b/tests/unit/set.cpp
@@ -20,6 +20,7 @@
 
 #include <graphblas.hpp>
 
+
 using namespace grb;
 
 void grb_program( const size_t &n, grb::RC &rc ) {
@@ -38,7 +39,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		for( const auto &pair : src ) {
 			if( pair.second != 1.5 ) {
 				std::cerr << "\t (set-to-value) unexpected entry "
-					<< ( " << pair.first << ", " << pair.second << " ), "
+					<< "( " << pair.first << ", " << pair.second << " ), "
 					<< "expected value 1.5.\n";
 				rc = FAILED;
 			}
@@ -125,9 +126,6 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	// test masked set
 	rc = grb::setElement( src, 0, n / 2 );
 	if( rc == SUCCESS ) {
-		rc = grb::clear( dst );
-	}
-	if( rc == SUCCESS ) {
 		rc = grb::set( dst, src, src );
 	}
 	if( rc != SUCCESS ) {
@@ -159,10 +157,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// test inverted-mask set
-	rc = grb::clear( dst );
-	if( rc == SUCCESS ) {
-		rc = grb::set< grb::descriptors::invert_mask >( dst, src, src );
-	}
+	rc = grb::set< grb::descriptors::invert_mask >( dst, src, src );
 	if( rc != SUCCESS ) {
 		std::cerr << "\t Inverted-mask set FAILED with error code "
 			<< grb::toString( rc ) << "\n";
@@ -191,13 +186,8 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		return;
 	}
 
-	// TODO continue code review from here. Also check if there is a set-to-empty test
-
 	// test sparse mask set
-	rc = grb::clear( dst );
-	if( rc == SUCCESS ) {
-		rc = grb::clear( src );
-	}
+	rc = grb::clear( src );
 	if( rc == SUCCESS ) {
 		rc = grb::setElement( src, 1.5, n / 2 );
 	}
@@ -205,19 +195,25 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		rc = grb::set( dst, src, src );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse-mask set FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse-mask set FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 1 ) {
-			std::cerr << "\t (sparse-mask-set) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
+			std::cerr << "\t (sparse-mask-set) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.first == n / 2 && pair.second != 1.5 ) {
-				std::cerr << "\t (sparse-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 1.5\n";
+				std::cerr << "\t (sparse-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5\n";
 				rc = FAILED;
 			}
 			if( pair.first != n / 2 ) {
-				std::cerr << "\t (sparse-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected no entry at this position\n";
+				std::cerr << "\t (sparse-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -231,19 +227,25 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	rc = rc ? rc : grb::setElement( src, 1.5, 0 );
 	rc = rc ? rc : grb::set( dst, src, src );
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse-mask set (re-entrance) FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse-mask set (re-entrance) FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 1 ) {
-			std::cerr << "\t (sparse-mask-set-reentrant) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
+			std::cerr << "\t (sparse-mask-set-reentrant) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
 		for( const auto &pair : dst ) {
-			if( (pair.first == 0 || pair.first == n/2)  && pair.second != 1.5 ) {
-				std::cerr << "\t (sparse-mask-set-reentrant) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 1.5\n";
+			if( pair.first == 0 && pair.second != 1.5 ) {
+				std::cerr << "\t (sparse-mask-set-reentrant) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5\n";
 				rc = FAILED;
 			}
-			if( pair.first != 0 && pair.first != n/2 ) {
-				std::cerr << "\t (sparse-mask-set-reentrant) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected no entry at this position\n";
+			if( pair.first != 0 ) {
+				std::cerr << "\t (sparse-mask-set-reentrant) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -253,10 +255,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// test sparse mask set to scalar
-	rc = grb::clear( dst );
-	if( rc == SUCCESS ) {
-		rc = grb::clear( src );
-	}
+	rc = grb::clear( src );
 	if( rc == SUCCESS ) {
 		rc = grb::setElement( src, 1.5, n / 2 );
 	}
@@ -264,19 +263,24 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		rc = grb::set( dst, src, 3.0 );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse-mask set to scalar FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse-mask set to scalar FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 1 ) {
-			std::cerr << "\t (sparse-mask-set-scalar) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
+			std::cerr << "\t (sparse-mask-set-scalar) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.first == n / 2 && pair.second != 3.0 ) {
-				std::cerr << "\t (sparse-mask-set-to-scalar) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 3.0\n";
+				std::cerr << "\t (sparse-mask-set-to-scalar) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), expected value 3.0\n";
 				rc = FAILED;
 			}
 			if( pair.first != n / 2 ) {
-				std::cerr << "\t (sparse-mask-set-to-scalar) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected no entry at this position\n";
+				std::cerr << "\t (sparse-mask-set-to-scalar) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -290,19 +294,25 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	rc = rc ? rc : grb::setElement( src, 1.5, 0 );
 	rc = rc ? rc : grb::set( dst, src, 3.0 );
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse-mask set to scalar (re-entrant) FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse-mask set to scalar (re-entrant) FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 1 ) {
-			std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
+			std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected number of "
+				<< "nonzeroes " << nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
 		for( const auto &pair : dst ) {
-			if( (pair.first == 0 || pair.first == n/2) && pair.second != 3.0 ) {
-				std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 3.0\n";
+			if( pair.first == 0 && pair.second != 3.0 ) {
+				std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 3.0\n";
 				rc = FAILED;
 			}
-			if( pair.first != 0 && pair.first != n/2 ) {
-				std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected no entry at this position\n";
+			if( pair.first != 0 ) {
+				std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected no entry at this position\n";
 				rc = FAILED;
 			}
 		}
@@ -312,19 +322,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// test sparse inverted mask set to empty
-	rc = grb::clear( dst );
-	if( rc == SUCCESS ) {
-		rc = grb::set< grb::descriptors::invert_mask >( dst, src, src );
-	}
+	rc = grb::set< grb::descriptors::invert_mask >( dst, src, src );
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse-inverted-mask set to empty FAILED with error "
-					 "code "
-				  << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse-inverted-mask set to empty FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != 0 ) {
-			std::cerr << "\t (sparse-inverted-mask-set-empty) unexpected "
-						 "number of nonzeroes "
-					  << nnz( dst ) << ", expected 0.\n";
+			std::cerr << "\t (sparse-inverted-mask-set-empty) unexpected number of "
+				<< "nonzeroes " << nnz( dst ) << ", expected 0.\n";
 			rc = FAILED;
 		}
 	}
@@ -334,10 +339,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 
 	// test sparse inverted mask set
 	grb::Vector< bool > mask( n );
-	rc = grb::clear( dst );
-	if( rc == SUCCESS ) {
-		rc = grb::setElement( mask, true, n / 2 );
-	}
+	rc = grb::setElement( mask, true, n / 2 );
 	if( rc == SUCCESS ) {
 		rc = grb::set( src, 1.5 );
 	}
@@ -345,25 +347,52 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		rc = grb::set< grb::descriptors::invert_mask >( dst, mask, src );
 	}
 	if( rc != SUCCESS ) {
-		std::cerr << "\t Sparse inverted-mask set FAILED with error code " << grb::toString( rc ) << "\n";
+		std::cerr << "\t Sparse inverted-mask set FAILED with error code "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( nnz( dst ) != n - 1 ) {
-			std::cerr << "\t (sparse-inverted-mask-set) unexpected number of "
-						 "nonzeroes "
-					  << nnz( dst ) << ", expected " << ( n - 1 ) << ".\n";
+			std::cerr << "\t (sparse-inverted-mask-set) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected " << (n - 1) << ".\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : dst ) {
+		for( const auto &pair : dst ) {
 			if( pair.first == n / 2 ) {
-				std::cerr << "\t (sparse-inverted-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << " ): this position should have been empty\n";
+				std::cerr << "\t (sparse-inverted-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "this position should have been empty\n";
 				rc = FAILED;
 			} else if( pair.second != 1.5 ) {
-				std::cerr << "\t (sparse-inverted-mask-set) unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 1.5.\n";
+				std::cerr << "\t (sparse-inverted-mask-set) unexpected entry "
+					<< "( " << pair.first << ", " << pair.second << " ), "
+					<< "expected value 1.5.\n";
 				rc = FAILED;
 			}
 		}
 	}
-	// if( rc != SUCCESS ) { return; }
+	if( rc != SUCCESS ) {
+		return;
+	}
+
+	rc = grb::clear( src );
+	if( rc == SUCCESS ) {
+		rc = grb::set( dst, src );
+	}
+	if( rc != SUCCESS ) {
+		std::cerr << "\t Set to empty vector FAILED with error code "
+			<< grb::toString( rc ) << "\n";
+	} else {
+		if( nnz( dst ) != 0 ) {
+			std::cerr << "\t (set-to-empty) unexpected number of nonzeroes "
+				<< nnz( dst ) << ", expected 0.\n";
+			rc = FAILED;
+		}
+		for( const auto &pair : dst ) {
+			std::cerr << "\t (set-to-empty) unexpected entry "
+				<< "( " << pair.first << ", " << pair.second << " ), "
+				<< "this position should have been empty\n";
+			rc = FAILED;
+		}
+	}
 
 	// done
 	return;
@@ -397,8 +426,8 @@ int main( int argc, char ** argv ) {
 	}
 	if( printUsage ) {
 		std::cerr << "Usage: " << argv[ 0 ] << " [n]\n";
-		std::cerr << "  -n (optional, default is 100): an even integer, the "
-					 "test size.\n";
+		std::cerr << "  -n (optional, default is 100): an even integer, "
+			<< "the test size.\n";
 		return 1;
 	}
 
@@ -416,3 +445,4 @@ int main( int argc, char ** argv ) {
 	}
 	return 0;
 }
+

--- a/tests/unit/set.cpp
+++ b/tests/unit/set.cpp
@@ -207,7 +207,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 	if( rc != SUCCESS ) {
 		std::cerr << "\t Sparse-mask set (re-entrance) FAILED with error code " << grb::toString( rc ) << "\n";
 	} else {
-		if( nnz( dst ) != 2 ) {
+		if( nnz( dst ) != 1 ) {
 			std::cerr << "\t (sparse-mask-set-reentrant) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}
@@ -266,7 +266,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 	if( rc != SUCCESS ) {
 		std::cerr << "\t Sparse-mask set to scalar (re-entrant) FAILED with error code " << grb::toString( rc ) << "\n";
 	} else {
-		if( nnz( dst ) != 2 ) {
+		if( nnz( dst ) != 1 ) {
 			std::cerr << "\t (sparse-mask-set-scalar-reentrant) unexpected number of nonzeroes " << nnz( dst ) << ", expected 1.\n";
 			rc = FAILED;
 		}


### PR DESCRIPTION
The `grb::set` did not follow out-of-place semantics, while one unit test designed to catch that was bugged. Additionally, the label propagation smoke test relied on the older in-place semantics.

This MR makes sure the existing nonzero structure of the output vector is cleared whenever the dense descriptor is not given. It fixes the corresponding unit test, and replaces the `grb::set( vector, mask, vector )` used by the label propagation algorithm (used for clamping) with the in-place `grb::foldl( vector, mask, vector )` using the `right_assign` operator.

This MR also includes the related changes and fixes listed below.
- Bugfix: introduces the previously missing masked vector-to-vector `grb::foldl` in the BSP1D backend;
- Bugfix: masked vector-to-vector folds with dense vectors but sparse masks would return `ILLEGAL` (the generic implementation could execute it, but did not because it was executing a dynamic check on the dense descriptor using a template argument that was not the exact reverse of being passed that descriptor-- this MR fixes this by lifting checks w.r.t. the dense descriptor out of the generic implementation);
- Bugfix: several variants of `grb::set` did not correctly return `ILLEGAL` when the dense descriptor was used;
- Performance: exchange `grb::set` with `std::swap` at various places in the label propagation algorithm;
- Performance: `grb::set` variants now do not call `assignAll` nor `clear` when a dense structure is assured to remain;
- Testing: unify output from label smoke tests and minor typo fix in `smoketests.sh`;
- Testing: `grb::set` unit test now also tests for correct behaviour when the dense descriptor is used;
- Code improvements: various code style fixes across files touched by this MR;
- Semantics & documentation: dense descriptor also applies to output containers.

Thanks to Aristeidis for finding the bug and implementing the initial fix to `grb::set`!