### PR TITLE
Resolve internal issue 564: bug in fold from vector to scalar fullloopsparse

### DIFF
--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -374,6 +374,9 @@ namespace grb {
 			const Vector< MaskType, reference, Coords > &mask,
 			const Monoid &monoid
 		) {
+#ifdef _DEBUG
+			std::cout << "Entered fold_from_vector_to_scalar_fullLoopSparse\n";
+#endif
 			const auto &to_fold_coors = internal::getCoordinates( to_fold );
 			const size_t n = to_fold_coors.size();
 			assert( n > 0 );
@@ -446,12 +449,12 @@ namespace grb {
 					monoid.template getIdentity< typename Monoid::D3 >();
 				if( end > 0 ) {
 					if( i < end ) {
+#ifdef _DEBUG
+						std::cout << "\t processing start index " << i << "\n";
+#endif
+
 						local = static_cast< typename Monoid::D3 >(
 								internal::getRaw( to_fold )[ i ]
-							);
-					} else {
-						local = static_cast< typename Monoid::D3 >(
-								internal::getRaw( to_fold )[ 0 ]
 							);
 					}
 				}
@@ -505,6 +508,10 @@ namespace grb {
 						if( i >= end ) {
 							break;
 						}
+
+#ifdef _DEBUG
+						std::cout << "\t processing index " << i << "\n";
+#endif
 
 						// store result of fold in local variable
 						RC local_rc;


### PR DESCRIPTION
The O(n) variant of folding a vector into a scalar that should deal with both sparsity of the vector as well as masks (the so-called fullLoopSparse variant), was in fact not checking for the sparsity of the input vector. All unit tests that could detect this issue were (apparently) instead triggering other variants (i.e., the maskDriven, the vectorDriven, or the dense variant)-- even though unit tests did exist for which the fullLoopSparse variant was triggered, those did not expose the bug detected here.

This MR fixes the bug, and adds a test case that reliably triggers the full sparse loop variant, by using a structural and inverted mask while assuring the sparsity pattern of the vector does not match that of the given (inverted) mask, which thus would also reliably trigger the detected bug. The MR also includes a minor code style fix and improved `_DEBUG` tracing.

Thanks to Aristeidis for detecting the bug!