### PR TITLE
565 k nn and mpv algorithms gives wrong results

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,6 +29,8 @@ to Huawei Technologies Co., Ltd. or one of its subsidiaries:
 
  - Auke Booij, Huawei Technologies Switzerland AG; 2021.
 
+ - Anders Hansson, Huawei Technologies Switzerland AG; 2022-2023.
+
 The experimental banshee backend has been developed in collaboration with
 Prof. Luca Benini at ETH Zuerich and his group. In particular this backend
 is with great thanks due to Dan, Paul Scheffler, Fabian Schuiki, and Samuel

--- a/include/graphblas/algorithms/mpv.hpp
+++ b/include/graphblas/algorithms/mpv.hpp
@@ -144,7 +144,7 @@ namespace grb {
 				ret = mxv< descr >( temp, A, u, ring );
 				// check if this was the final multiplication
 				assert( iterate <= k );
-				if( iterate == k || ret != SUCCESS ) {
+				if( iterate + 1 == k || ret != SUCCESS ) {
 					break;
 				}
 				// multiply with output into u

--- a/tests/performance/performancetests.sh
+++ b/tests/performance/performancetests.sh
@@ -70,8 +70,8 @@ fi
 DATASETS=(west0497.mtx facebook_combined.txt cit-HepTh.txt com-amazon.ungraph.txt com-youtube.ungraph.txt cit-Patents.txt com-orkut.ungraph.txt)
 DATASET_MODES=(direct direct indirect indirect indirect indirect indirect)
 DATASET_SIZES=(497 4039 27770 334863 1134890 3774768 3072441)
-KNN4SOLS=(118 499 2805 1 64 1 1048907)
-KNN6SOLS=(357 547 5176 1 246 1 1453447)
+KNN4SOLS=(59 421 1138 1 32 1 1048907)
+KNN6SOLS=(238 526 4189 1 181 1 1268035)
 
 #the following datasets are used for benchmarking SpMV, SpMSpV, and SpMSpM
 MULTIPLICATION_DATASETS=(west0497.mtx fidap037.mtx cavity17.mtx s3rmt3m3.mtx bloweybq.mtx bcsstk17.mtx Pres_Poisson.mtx gyro_m.mtx memplus.mtx lhr34.mtx bcsstk32.mtx vanbody.mtx s3dkt3m2.mtx G2_circuit.mtx Stanford.mtx coPapersCiteseer.mtx bundle_adj.mtx Stanford_Berkeley.mtx apache2.mtx Emilia_923.mtx ldoor.mtx ecology2.mtx Serena.mtx cage14.mtx G3_circuit.mtx wikipedia-20051105.mtx wikipedia-20061104.mtx Freescale1.mtx wikipedia-20070206.mtx Queen_4147.mtx cage15.mtx adaptive.mtx rgg_n_2_24_s0.mtx uk-2002.mtx road_usa.mtx MOLIERE_2016.mtx europe_osm.mtx twitter.mtx com-Friendster.mtx)

--- a/tests/performance/performancetests.sh
+++ b/tests/performance/performancetests.sh
@@ -70,7 +70,7 @@ fi
 DATASETS=(west0497.mtx facebook_combined.txt cit-HepTh.txt com-amazon.ungraph.txt com-youtube.ungraph.txt cit-Patents.txt com-orkut.ungraph.txt)
 DATASET_MODES=(direct direct indirect indirect indirect indirect indirect)
 DATASET_SIZES=(497 4039 27770 334863 1134890 3774768 3072441)
-KNN4SOLS=(59 421 1138 1 32 1 1048907)
+KNN4SOLS=(59 421 1138 1 32 1 609122)
 KNN6SOLS=(238 526 4189 1 181 1 1268035)
 
 #the following datasets are used for benchmarking SpMV, SpMSpV, and SpMSpM

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -126,7 +126,7 @@ for BACKEND in ${BACKENDS[@]}; do
 				$runner ${TEST_BIN_DIR}/knn_${BACKEND} 4 ${INPUT_DIR}/facebook_combined.txt direct 1 1 &> ${TEST_OUT_DIR}/knn_${BACKEND}_${P}_${T}_facebook.log
 				head -1 ${TEST_OUT_DIR}/knn_${BACKEND}_${P}_${T}_facebook.log
 				if grep -q "Test OK" ${TEST_OUT_DIR}/knn_${BACKEND}_${P}_${T}_facebook.log; then
-					(grep -q "Neighbourhood size is 499" ${TEST_OUT_DIR}/knn_${BACKEND}_${P}_${T}_facebook.log && printf "Test OK\n\n") || (printf "Test FAILED (verification error)\n")
+					(grep -q "Neighbourhood size is 421" ${TEST_OUT_DIR}/knn_${BACKEND}_${P}_${T}_facebook.log && printf "Test OK\n\n") || (printf "Test FAILED (verification error)\n")
 				else
 					printf "Test FAILED\n"
 				fi


### PR DESCRIPTION
Anders detected an off-by-one error in the mpv (matrix powers) kernel / algorithm, which this MR fixes. This affects the k-NN algorithms as well as the smoke and performance tests based on it, which were previously verified against the sequential ALP/GraphBLAS baseline. This MR also hardens these tests by comparing against a ground truth verified by an external framework, in this case Octave.
This MR has been thoroughly tested using the full test suite. Additionally, an issue (GitHub #136) has been raised to consider an mpv implementation which is not unrolled and simply based on `std::swap`-- suspected is that the current implementation predates supporting swap, and, different from an implementation using `grb::set` instead of swap, a major performance loss compared to an unrolled algorithm no longer is expected.