### PR TITLE
106 internal ci picks up assert failure in hyperdags backend

### DIFF
--- a/include/graphblas/hyperdags/blas3.hpp
+++ b/include/graphblas/hyperdags/blas3.hpp
@@ -106,9 +106,10 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( nrows( A ) == 0 || ncols( A ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 2 > sourcesC{
+		std::array< uintptr_t, 3 > sourcesC{
 			getID( internal::getMatrix(A) ),
-			getID( internal::getMatrix(B) )
+			getID( internal::getMatrix(B) ),
+			getID( internal::getMatrix(C) ),
 		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getMatrix(C) ) };
 		internal::hyperdags::generator.addOperation(

--- a/tests/unit/zip.cpp
+++ b/tests/unit/zip.cpp
@@ -20,10 +20,14 @@
 
 #include <graphblas.hpp>
 
+
 using namespace grb;
 
 void grb_program( const size_t & n, grb::RC & rc ) {
-	grb::Semiring< grb::operators::add< double >, grb::operators::mul< double >, grb::identities::zero, grb::identities::one > ring;
+	grb::Semiring<
+		grb::operators::add< double >, grb::operators::mul< double >,
+		grb::identities::zero, grb::identities::one
+	> ring;
 	grb::Vector< double > left( n ), chk1( n );
 	grb::Vector< int > right( n ), chk2( n );
 	grb::Vector< std::pair< double, int > > out( n );
@@ -42,13 +46,16 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		return;
 	}
 	if( nnz( out ) != n ) {
-		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( out ) << ", expected " << n << " )\n";
+		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( out )
+			<< ", expected " << n << " )\n";
 		rc = FAILED;
 	}
-	for( const auto & pair : out ) {
+	for( const auto &pair : out ) {
 		const std::pair< double, int > & out = pair.second;
 		if( out.first != 1.5 || out.second != 2 ) {
-			std::cerr << "\t unexpected output ( " << pair.first << ", < " << out.first << ", " << out.second << " > ), expected " << pair.first << ", < 1.5, 2 > )\n";
+			std::cerr << "\t unexpected output "
+				<< "( " << pair.first << ", < " << out.first << ", "
+				<< out.second << " > ), expected " << pair.first << ", < 1.5, 2 > )\n";
 			rc = FAILED;
 		}
 	}
@@ -62,22 +69,26 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		return;
 	}
 	if( nnz( chk1 ) != n ) {
-		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( chk1 ) << ", expected " << n << "\n";
+		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( chk1 ) << ", "
+			<< "expected " << n << "\n";
 		rc = FAILED;
 	}
 	if( nnz( chk2 ) != n ) {
-		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( chk2 ) << ", expected " << n << "\n";
+		std::cerr << "\t unexpected number of nonzeroes ( " << nnz( chk2 ) << ", "
+			<< "expected " << n << "\n";
 		rc = FAILED;
 	}
-	for( const auto & pair : chk1 ) {
+	for( const auto &pair : chk1 ) {
 		if( pair.second != 1.5 ) {
-			std::cerr << "\t unexpected output ( " << pair.first << ", " << pair.second << " ), expected " << pair.first << ", 1.5 )\n";
+			std::cerr << "\t unexpected output ( " << pair.first << ", " << pair.second
+				<< " ), expected " << pair.first << ", 1.5 )\n";
 			rc = FAILED;
 		}
 	}
 	for( const auto & pair : chk2 ) {
 		if( pair.second != 2 ) {
-			std::cerr << "\t unexpected output ( " << pair.first << ", " << pair.second << " ), expected " << pair.first << ", 2 )\n";
+			std::cerr << "\t unexpected output ( " << pair.first << ", " << pair.second
+				<< " ), expected " << pair.first << ", 2 )\n";
 			rc = FAILED;
 		}
 	}


### PR DESCRIPTION
The internal CI builds unit and smoke tests in the `develop` branch (also) using the debug mode (in addition to the standard release mode), which after a totally unrelated commit failed for unit tests that call `eWiseApply` on matrices, for the hyperdags backend only.

The issue was that the output matrix was not correctly registered as a source, resulting in containers being "lost" in the internal hyperdag representation-- for which `src/hyperdags/hyperdag.cpp` has an assertion check. Indeed, assertion checks in sources are only active when compiled in Debug mode, though it remains unclear why those unit tests did not fail before.

