### PR TITLE
Resolves internal issue #577: two bugs related to eWiseApply

### DIFF
--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -6132,25 +6132,25 @@ namespace grb {
 #ifdef _H_GRB_REFERENCE_OMP_BLAS1
 						if( z_coors.asyncAssign( index, localUpdate ) ) {
 #else
-							if( z_coors.assign( index ) ) {
+						if( z_coors.assign( index ) ) {
 #endif
-								typename Ring::D4 b = static_cast< typename Ring::D4 >( z[ index ] );
-								(void) foldr( t, b, ring.getAdditiveOperator() );
-								z[ index ] = static_cast< OutputType >( b );
-							} else {
-								z[ index ] = static_cast< OutputType >(
-									static_cast< typename Ring::D4 >( t )
-								);
+							typename Ring::D4 b = static_cast< typename Ring::D4 >( z[ index ] );
+							(void) foldr( t, b, ring.getAdditiveOperator() );
+							z[ index ] = static_cast< OutputType >( b );
+						} else {
+							z[ index ] = static_cast< OutputType >(
+								static_cast< typename Ring::D4 >( t )
+							);
 #ifdef _H_GRB_REFERENCE_OMP_BLAS1
-								(void) ++asyncAssigns;
-								if( asyncAssigns == maxAsyncAssigns ) {
-									(void) z_coors.joinUpdate( localUpdate );
-									asyncAssigns = 0;
-								}
-#endif
+							(void) ++asyncAssigns;
+							if( asyncAssigns == maxAsyncAssigns ) {
+								(void) z_coors.joinUpdate( localUpdate );
+								asyncAssigns = 0;
 							}
+#endif
 						}
 					}
+				}
 #ifdef _H_GRB_REFERENCE_OMP_BLAS1
 				while( !z_coors.joinUpdate( localUpdate ) ) {}
 			}

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -3306,7 +3306,7 @@ namespace grb {
 #endif
 					for( ; k < loop_coors.nonzeroes(); ++k ) {
 						const size_t index = loop_coors.index( k );
-						if( masked && mask_coors->template mask< descr >( index, mask_p ) ) {
+						if( masked && !mask_coors->template mask< descr >( index, mask_p ) ) {
 							continue;
 						}
 						RC rc = SUCCESS;
@@ -3518,7 +3518,7 @@ namespace grb {
 							if( loop_coors.assigned( index ) ) {
 								continue;
 							}
-							if( masked && mask_coors->template mask< descr >( index, mask_p ) ) {
+							if( masked && !mask_coors->template mask< descr >( index, mask_p ) ) {
 								continue;
 							}
 #ifndef _H_GRB_REFERENCE_OMP_BLAS1

--- a/tests/unit/ewiseapply.cpp
+++ b/tests/unit/ewiseapply.cpp
@@ -660,10 +660,12 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	rc = grb::eWiseApply( out, mask, right, right, plusM );
 	assert( rc == SUCCESS );
 	if( rc == SUCCESS ) {
-		if( nnz( out ) != nnz( right ) / 2 ) {
+		const bool halfIsOdd = ((n / 2) % 2) == 1;
+		if( nnz( out ) != nnz( right ) / 2 + (halfIsOdd ? 1 : 0) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
 				<< "expected " << nnz( right ) / 2 << " ) at subtest 22\n";
 			rc = FAILED;
+			assert( false ); // DBG
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {

--- a/tests/unit/ewiseapply.cpp
+++ b/tests/unit/ewiseapply.cpp
@@ -20,6 +20,7 @@
 
 #include <graphblas.hpp>
 
+
 using namespace grb;
 
 void grb_program( const size_t &n, grb::RC &rc ) {
@@ -659,30 +660,108 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 
 	rc = grb::eWiseApply( out, mask, right, right, plusM );
 	assert( rc == SUCCESS );
+	const bool halfIsOdd = ((n / 2) % 2) == 1;
 	if( rc == SUCCESS ) {
-		const bool halfIsOdd = ((n / 2) % 2) == 1;
-		if( nnz( out ) != nnz( right ) / 2 + (halfIsOdd ? 1 : 0) ) {
+		const size_t expected = nnz( right ) / 2 + (halfIsOdd ? 1 : 0);
+		if( nnz( out ) != expected ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << nnz( right ) / 2 << " ) at subtest 22\n";
+				<< "expected " << expected << " ) at subtest 22\n";
 			rc = FAILED;
-			assert( false ); // DBG
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != static_cast< double >( .5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 0.5 ) at subtest 22\n";
+							<< " ), expected ( " << pair.first << ", 0.5 ) at subtest 22\n";
 						rc = FAILED;
 					}
 				} else {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected nothing at this entry) at subtest 22\n";
+						<< " ), expected nothing at this entry at subtest 22\n";
 					rc = FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this index) at subtest 22\n";
+					<< " ), expected nothing at this index at subtest 22\n";
+				rc = FAILED;
+			}
+		}
+		if( rc == FAILED ) {
+			return;
+		}
+	} else {
+		return;
+	}
+
+	rc = clear( right );
+	rc = rc ? rc : clear( left );
+	rc = rc ? rc : setElement( right, 2.17, 0 );
+	rc = rc ? rc : setElement( right, 2.0, n/2 );
+	rc = rc ? rc : setElement( right, 3.14, n-1 );
+	rc = rc ? rc : setElement( left,  1.0, n-1 );
+	rc = rc ? rc : setElement( left, -1.0, 0 );
+	rc = eWiseApply( out, mask, left, right, plusM );
+	assert( n % 2 == 0 );
+	assert( rc == SUCCESS );
+	if( rc == SUCCESS ) {
+		const size_t expect = 1;
+		if( nnz( out ) != expect ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
+				<< "), expected " << expect << " ) at subtest 23\n";
+			rc = FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.first == 0 ) {
+				if( pair.second != 1.17 ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 23\n";
+					rc = FAILED;
+				}
+			} else {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< " ), expected ( " << pair.first << ", " << (n/2) << " ) "
+					<< "at subtest 23\n";
+				rc = FAILED;
+			}
+		}
+		if( rc == FAILED ) {
+			return;
+		}
+	} else {
+		return;
+	}
+
+	rc = grb::eWiseApply( out, left, right, plusM );
+	assert( rc == SUCCESS );
+	if( rc == SUCCESS ) {
+		if( nnz( out ) != 3 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
+				<< "expected " << 3 << " ) at subtest 24\n";
+			rc = FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.first == 0 ) {
+				if( pair.second != 1.17 ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 24\n";
+					rc = FAILED;
+				}
+			} else if( pair.first == n / 2 ) {
+				if( pair.second != 2.0 ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< " ), expected ( " << pair.first << ", 2.0 ) at subtest 24\n";
+					rc = FAILED;
+				}
+			} else if( pair.first == n - 1 ) {
+				if( !utils::equals( pair.second, 4.14, 1 ) ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< " ), expected ( " << pair.first << ", 4.14 ) at subtest 24\n";
+					rc = FAILED;
+				}
+			} else {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< ", expected nothing at this index at subtest 24\n";
 				rc = FAILED;
 			}
 		}

--- a/tests/unit/unittests.sh
+++ b/tests/unit/unittests.sh
@@ -195,16 +195,17 @@ for MODE in debug ndebug; do
 				echo " "
 
 				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using (+,0) on vectors"
+				echo "                                 of doubles of size 14."
+				$runner ${TEST_BIN_DIR}/ewiseapply_${MODE}_${BACKEND} 14 &> ${TEST_OUT_DIR}/ewiseapply_small_${MODE}_${BACKEND}_${P}_${T}
+				head -1 ${TEST_OUT_DIR}/ewiseapply_small_${MODE}_${BACKEND}_${P}_${T}
+				grep 'Test OK' ${TEST_OUT_DIR}/ewiseapply_small_${MODE}_${BACKEND}_${P}_${T} || echo "Test FAILED"
+				echo " "
+
+				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using (+,0) on vectors"
 				echo "                                 of doubles of size 100."
 				$runner ${TEST_BIN_DIR}/ewiseapply_${MODE}_${BACKEND} 100 &> ${TEST_OUT_DIR}/ewiseapply_${MODE}_${BACKEND}_${P}_${T}
 				head -1 ${TEST_OUT_DIR}/ewiseapply_${MODE}_${BACKEND}_${P}_${T}
 				grep 'Test OK' ${TEST_OUT_DIR}/ewiseapply_${MODE}_${BACKEND}_${P}_${T} || echo "Test FAILED"
-				echo " "
-
-				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using + on matrices"
-				$runner ${TEST_BIN_DIR}/eWiseApply_matrix_${MODE}_${BACKEND} &> ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T}
-				head -1 ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T}
-				grep 'Test OK' ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T} || echo "Test FAILED"
 				echo " "
 
 				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using (+,0) on vectors"
@@ -212,6 +213,12 @@ for MODE in debug ndebug; do
 				$runner ${TEST_BIN_DIR}/ewiseapply_${MODE}_${BACKEND} 10000000 &> ${TEST_OUT_DIR}/ewiseapply_large_${MODE}_${BACKEND}_${P}_${T}
 				head -1 ${TEST_OUT_DIR}/ewiseapply_large_${MODE}_${BACKEND}_${P}_${T}
 				grep 'Test OK' ${TEST_OUT_DIR}/ewiseapply_large_${MODE}_${BACKEND}_${P}_${T} || echo "Test FAILED"
+				echo " "
+
+				echo ">>>      [x]           [ ]       Testing grb::eWiseApply using + on matrices"
+				$runner ${TEST_BIN_DIR}/eWiseApply_matrix_${MODE}_${BACKEND} &> ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T}
+				head -1 ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T}
+				grep 'Test OK' ${TEST_OUT_DIR}/eWiseApply_matrix_${MODE}_${BACKEND}_${P}_${T} || echo "Test FAILED"
 				echo " "
 
 				echo ">>>      [x]           [ ]       Testing grb::zip on two vectors of doubles and"


### PR DESCRIPTION
Aristeidis detected that the unit test for `eWiseApply` could fail for some vector lengths that `unittests.sh` never calls it with, and also detected that the sparse-vector driven variant of `eWiseApply` did not correctly check for output mask conditions. The underlying issues were a metabug in the unit test that did not deal properly with vector lengths whose half is an odd number, and a missing negation of the evaluated mask. This MR fixes both issues, and also:
- executes the `eWiseApply` unit test for vectors of length `14`, thus triggering the detecting meta-bug should it ever regress;
- adds to sub-tests to the `eWiseApply` unit test designed to trigger the sparse-vector driven variant with a non-trivial mask that would detect erroneous mask evaluations, thus triggering detection of the main bug this MR fixes;
- improved the output of the `eWiseApply` unit tests; and
- fixes an unrelated code style issue (incorrect indentation).