### PR TITLE
Resolves internal issue #593: dangling include in reference matrix

### DIFF
--- a/include/graphblas/algorithms/spy.hpp
+++ b/include/graphblas/algorithms/spy.hpp
@@ -20,6 +20,7 @@
 #define _H_GRB_ALGORITHMS_SPY
 
 #include <type_traits>
+#include <vector>
 
 #include <graphblas.hpp>
 

--- a/include/graphblas/reference/matrix.hpp
+++ b/include/graphblas/reference/matrix.hpp
@@ -46,8 +46,6 @@
 #include <graphblas/utils/autodeleter.hpp>
 #include <graphblas/utils/DMapper.hpp>
 #include <graphblas/type_traits.hpp>
-
-#include <graphblas/algorithms/hpcg/ndim_matrix_builders.hpp>
 #include <graphblas/utils/iterators/utils.hpp>
 
 #include "NonzeroWrapper.hpp"


### PR DESCRIPTION
Alberto detected an erroneous include in the reference `matrix.hpp`, and a missing include in the spy algorithm. This MR fixes both issues. Many thanks for both detecting the bug and for providing the fix!