### PR TITLE
134 additional internal ci failures triggered for hyperdag in debug mode

### DIFF
--- a/include/graphblas/hyperdags/blas1.hpp
+++ b/include/graphblas/hyperdags/blas1.hpp
@@ -166,7 +166,11 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( size( internal::getVector(in) ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 1 > sourcesC{ getID( internal::getVector(in) ) };
+		std::array< uintptr_t, 3 > sourcesC{
+			getID( internal::getVector(x) ),
+			getID( internal::getVector(y) ),
+			getID( internal::getVector(in) )
+		};
 		std::array< uintptr_t, 2 > destinations{
 			getID( internal::getVector(x) ),
 			getID( internal::getVector(y) )
@@ -207,9 +211,10 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( size( internal::getVector(x) ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 2 > sourcesC{
+		std::array< uintptr_t, 3 > sourcesC{
 			getID( internal::getVector(x) ),
-			getID( internal::getVector(y) )
+			getID( internal::getVector(y) ),
+			getID( internal::getVector(z) )
 		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getVector(z) ) };
 		internal::hyperdags::generator.addOperation(
@@ -1394,7 +1399,10 @@ namespace grb {
 			&beta
 		);
 		std::array< const void *, 1 > sourcesP{ &beta };
-		std::array< uintptr_t, 1 > sourcesC{ getID( internal::getVector(x) ) };
+		std::array< uintptr_t, 2 > sourcesC{
+			getID( internal::getVector(x) ),
+			getID( internal::getVector(z) )
+		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getVector(z) ) };
 		internal::hyperdags::generator.addOperation(
 			internal::hyperdags::EWISEAPPLY_VECTOR_SCALAR_MONOID,
@@ -1436,7 +1444,10 @@ namespace grb {
 			&alpha
 		);
 		std::array< const void *, 1 > sourcesP{ &alpha };
-		std::array< uintptr_t, 1 > sourcesC{ getID( internal::getVector(y) ) };
+		std::array< uintptr_t, 2 > sourcesC{
+			getID( internal::getVector(y) ),
+			getID( internal::getVector(z) )
+		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getVector(z) ) };
 		internal::hyperdags::generator.addOperation(
 			internal::hyperdags::EWISEAPPLY_SCALAR_VECTOR_MONOID,
@@ -1478,10 +1489,11 @@ namespace grb {
 		if( ret != SUCCESS ) { return ret; }
 		if( phase != EXECUTE ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 3 > sourcesC{
+		std::array< uintptr_t, 4 > sourcesC{
 			getID( internal::getVector(mask) ),
 			getID( internal::getVector(x) ),
-			getID( internal::getVector(y) )
+			getID( internal::getVector(y) ),
+			getID( internal::getVector(z) )
 		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getVector(z) ) };
 		internal::hyperdags::generator.addOperation(
@@ -1520,9 +1532,10 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( size( internal::getVector(x) ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 2 > sourcesC{
+		std::array< uintptr_t, 3 > sourcesC{
 			getID( internal::getVector(x) ),
-			getID( internal::getVector(y) )
+			getID( internal::getVector(y) ),
+			getID( internal::getVector(z) )
 		};
 		std::array< uintptr_t, 1 > destinations{ getID( internal::getVector(z) ) };
 		internal::hyperdags::generator.addOperation(

--- a/tests/unit/zip.cpp
+++ b/tests/unit/zip.cpp
@@ -55,7 +55,8 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		if( out.first != 1.5 || out.second != 2 ) {
 			std::cerr << "\t unexpected output "
 				<< "( " << pair.first << ", < " << out.first << ", "
-				<< out.second << " > ), expected " << pair.first << ", < 1.5, 2 > )\n";
+				<< out.second << " > ), expected " << pair.first << ", "
+				<< "< 1.5, 2 > )\n";
 			rc = FAILED;
 		}
 	}
@@ -122,48 +123,56 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		rc = grb::zip( A, I, J, V );
 	}
 	if( rc != SUCCESS ) {
-		std::cout << "grb::zip to matrix (non-void) FAILED with error " << grb::toString( rc ) << "\n";
+		std::cout << "grb::zip to matrix (non-void) FAILED with error "
+			<< grb::toString( rc ) << "\n";
 	} else {
 		if( grb::nnz( A ) != n ) {
-			std::cout << "\t got " << grb::nnz( A ) << " matrix nonzeroes, expected " << n << "\n";
+			std::cout << "\t got " << grb::nnz( A ) << " matrix nonzeroes, "
+				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
 		// check via grb::mxv
-		(void)grb::set( right, 1 );
-		(void)grb::clear( left );
-		(void)grb::vxm( left, right, A, ring );
+		(void) grb::set( right, 1 );
+		(void) grb::clear( left );
+		(void) grb::vxm( left, right, A, ring );
 		if( grb::nnz( left ) != 2 ) {
-			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, expected 2\n";
+			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, "
+				<< "expected 2\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : left ) {
+		for( const auto &pair : left ) {
 			if( pair.first == 1 ) {
 				const double expect = n - 1 + ( 1 == n / 2 ? 1 : 0 );
 				if( pair.second != expect ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected " << expect << "\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected " << expect << "\n";
 					rc = FAILED;
 				}
 			} else if( pair.first == n / 2 && n / 2 != 1 ) {
 				if( pair.second != 1 ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected 1\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected 1\n";
 					rc = FAILED;
 				}
 			} else {
 				if( pair.second != 0 ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected none\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected none\n";
 					rc = FAILED;
 				}
 			}
 		}
-		(void)grb::clear( left );
-		(void)grb::mxv( left, A, right, ring );
+		(void) grb::clear( left );
+		(void) grb::mxv( left, A, right, ring );
 		if( grb::nnz( left ) != n ) {
-			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, expected " << n << "\n";
+			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, "
+				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
 		for( const auto & pair : left ) {
 			if( pair.second != 1 ) {
-				std::cout << "\t got unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 1.\n";
+				std::cout << "\t got unexpected entry ( " << pair.first << ", "
+					<< pair.second << " ), expected value 1.\n";
 				rc = FAILED;
 			}
 		}
@@ -178,48 +187,56 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 		rc = grb::zip( A_void, I, J );
 	}
 	if( rc != SUCCESS ) {
-		std::cout << "grb::zip to matrix (void) FAILED with error " << grb::toString( rc ) << "\n";
+		std::cout << "grb::zip to matrix (void) FAILED with error " << grb::toString( rc )
+			<< "\n";
 	} else {
 		if( grb::nnz( A_void ) != n ) {
-			std::cout << "\t got " << grb::nnz( A_void ) << " matrix nonzeroes, expected " << n << "\n";
+			std::cout << "\t got " << grb::nnz( A_void ) << " matrix nonzeroes, "
+				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
 		// check via grb::mxv
-		(void)grb::set( right, 1 );
-		(void)grb::clear( left );
-		(void)grb::vxm( left, right, A_void, ring );
+		(void) grb::set( right, 1 );
+		(void) grb::clear( left );
+		(void) grb::vxm( left, right, A_void, ring );
 		if( grb::nnz( left ) != 2 ) {
-			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, expected 2\n";
+			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, "
+				<< "expected 2\n";
 			rc = FAILED;
 		}
 		for( const auto & pair : left ) {
 			if( pair.first == 1 ) {
 				const double expect = n - 1 + ( 1 == n / 2 ? 1 : 0 );
 				if( pair.second != expect ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected " << expect << "\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected " << expect << "\n";
 					rc = FAILED;
 				}
 			} else if( pair.first == n / 2 && n / 2 != 1 ) {
 				if( pair.second != 1 ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected 1\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected 1\n";
 					rc = FAILED;
 				}
 			} else {
 				if( pair.second != 0 ) {
-					std::cout << "\t got " << pair.second << " nonzeroes in column " << pair.first << ", expected none\n";
+					std::cout << "\t got " << pair.second << " nonzeroes in column "
+						<< pair.first << ", expected none\n";
 					rc = FAILED;
 				}
 			}
 		}
-		(void)grb::clear( left );
-		(void)grb::mxv( left, A_void, right, ring );
+		(void) grb::clear( left );
+		(void) grb::mxv( left, A_void, right, ring );
 		if( grb::nnz( left ) != n ) {
-			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, expected " << n << "\n";
+			std::cout << "\t got " << grb::nnz( left ) << " nonzeroes in output vector, "
+				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
 		for( const auto & pair : left ) {
 			if( pair.second != 1 ) {
-				std::cout << "\t got unexpected entry ( " << pair.first << ", " << pair.second << " ): expected value 1.\n";
+				std::cout << "\t got unexpected entry ( " << pair.first << ", "
+					<< pair.second << " ): expected value 1.\n";
 				rc = FAILED;
 			}
 		}
@@ -261,7 +278,7 @@ int main( int argc, char ** argv ) {
 	if( printUsage ) {
 		std::cerr << "Usage: " << argv[ 0 ] << " [n]\n";
 		std::cerr << "  -n (optional, default is 100): an even integer, the "
-					 "test size.\n";
+			"test size.\n";
 		return 1;
 	}
 
@@ -273,9 +290,11 @@ int main( int argc, char ** argv ) {
 		return 255;
 	}
 	if( out != SUCCESS ) {
-		std::cerr << "Test FAILED (" << grb::toString( out ) << ")" << std::endl;
+		std::cerr << "Test FAILED (" << grb::toString( out ) << ")\n"
+			<< std::endl;
 	} else {
-		std::cout << "Test OK" << std::endl;
+		std::cout << "Test OK\n" << std::endl;
 	}
 	return 0;
 }
+

--- a/tests/unit/zip.cpp
+++ b/tests/unit/zip.cpp
@@ -86,7 +86,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 			rc = FAILED;
 		}
 	}
-	for( const auto & pair : chk2 ) {
+	for( const auto &pair : chk2 ) {
 		if( pair.second != 2 ) {
 			std::cerr << "\t unexpected output ( " << pair.first << ", " << pair.second
 				<< " ), expected " << pair.first << ", 2 )\n";
@@ -169,7 +169,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : left ) {
+		for( const auto &pair : left ) {
 			if( pair.second != 1 ) {
 				std::cout << "\t got unexpected entry ( " << pair.first << ", "
 					<< pair.second << " ), expected value 1.\n";
@@ -204,7 +204,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 				<< "expected 2\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : left ) {
+		for( const auto &pair : left ) {
 			if( pair.first == 1 ) {
 				const double expect = n - 1 + ( 1 == n / 2 ? 1 : 0 );
 				if( pair.second != expect ) {
@@ -233,7 +233,7 @@ void grb_program( const size_t & n, grb::RC & rc ) {
 				<< "expected " << n << "\n";
 			rc = FAILED;
 		}
-		for( const auto & pair : left ) {
+		for( const auto &pair : left ) {
 			if( pair.second != 1 ) {
 				std::cout << "\t got unexpected entry ( " << pair.first << ", "
 					<< pair.second << " ): expected value 1.\n";


### PR DESCRIPTION
Internal CI detects errors in the hyperDAGs backend for the `eWiseApply` and `zip` unit tests, as well as in the `hpcg` smoke test, only when run in debug mode (without `-DNDEBUG`).

Issue: the debug mode detects disconnected hyperDAGs when they are dumped. This indicates a vertex from which there is no path to some output.

Cause: some variants of `eWiseApply` did not connect to the output container as an input to the `eWiseApply`. This sounds paradoxical since this primitive is out of place, but like for the `clear`, the container must still be registered as a source because its previous contents are invalidated. The same issue existed for `unzip`.

This MR fixes both issues, and fixes the code style of the `tests/unit/zip.cpp` unit test.

