### PR TITLE
Fixes bug in HyperDAG backend detected by internal CI

### DIFF
--- a/include/graphblas/hyperdags/blas3.hpp
+++ b/include/graphblas/hyperdags/blas3.hpp
@@ -274,7 +274,8 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( nrows( A ) == 0 || ncols( A ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 3 > sourcesC{
+		std::array< uintptr_t, 4 > sourcesC{
+			getID( internal::getMatrix(A) ),
 			getID( internal::getVector(x) ),
 			getID( internal::getVector(y) ),
 			getID( internal::getVector(z) )
@@ -310,7 +311,8 @@ namespace grb {
 		if( phase != EXECUTE ) { return ret; }
 		if( nrows( A ) == 0 || ncols( A ) == 0 ) { return ret; }
 		std::array< const void *, 0 > sourcesP{};
-		std::array< uintptr_t, 2 > sourcesC{
+		std::array< uintptr_t, 3 > sourcesC{
+			getID( internal::getMatrix(A) ),
 			getID( internal::getVector(x) ),
 			getID( internal::getVector(y) )
 		};


### PR DESCRIPTION
The internal CI detected the zip unit test failing for the hyperdags backend, when built in debug release mode.

The cause was that the zip (vector x vector -> matrix), for both pattern and non-pattern matrices did not register the output matrix as a source in the hyperDAG to be generated, thus causing vertices to be "lost". The hyperDAG backend includes an (expensive) sanity check against this, but only when compiled in debug release. This MR fixes the implementation of both matrix zip variants.