### PR TITLE
146 33 support serialised internal CI execution and _DEBUG checks on GitHub

### DIFF
--- a/.github/workflows/dbg_smoke.yml
+++ b/.github/workflows/dbg_smoke.yml
@@ -1,0 +1,37 @@
+
+name: smoke-tests
+
+on: [push]
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install required packages
+      run: sudo apt-get install -y libnuma-dev
+
+    - name: Configure
+      run: mkdir build && cd build && ../bootstrap.sh --prefix=../install --debug-build
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      run: make -j4
+
+    - name: Install
+      working-directory: ${{github.workspace}}/build
+      run: make -j4 install
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: make -j4 smoketests &> smoketests.log
+
+    - name: Check
+      working-directory: ${{github.workspace}}/build
+      run: ../tests/summarise.sh smoketests.log
+

--- a/.github/workflows/dbg_smoke.yml
+++ b/.github/workflows/dbg_smoke.yml
@@ -1,5 +1,5 @@
 
-name: smoke-tests
+name: debug-smoke-tests
 
 on: [push]
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,5 @@
 
-name: smoke-tests
+name: release-smoke-tests
 
 on: [push]
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ stages:
 #    exclude:
 #      - build/**/*.o
 #      - build/**/*.o.d
-#    expire_in: 30 minutes
+#    expire_in: 80 minutes
 
 
 #build_debug_centos_8:
@@ -131,7 +131,7 @@ build_test:
       - build/**/*.o.d
       - build/**/CMakeFiles
       - build/**/*.dir
-    expire_in: 30 minutes
+    expire_in: 80 minutes
 
 
 build_debug2_tests:
@@ -225,7 +225,7 @@ build_debug:
     exclude:
       - build/**/*.o
       - build/**/*.o.d
-    expire_in: 30 minutes
+    expire_in: 43 minutes
 
 
 test_smoke_debug:


### PR DESCRIPTION
A serialised execution of the internal CI could fail due to artifacts expiring. As GitHub issue #146 suggests, this MR increases the artifact time-outs. Sometimes the internal CI picks up errors related to a debug build that are missed by the GitHub CI. As GitHub issue #33 suggests, this MR enables (cheap) debug release checks on the GitHub CI also.