### PR TITLE
Speed up several cases of unmasked grb::set when the dense descriptor is given

### DIFF
--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -760,7 +760,7 @@ namespace grb {
 						index = internal::getCoordinates( x ).asyncCopy(
 							internal::getCoordinates( y ), i );
 					} else {
-						index = start;
+						index = i;
 					}
 					if( !out_is_void && !in_is_void ) {
 						dst[ index ] = internal::setIndexOrValue< descr, OutputType >(

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -664,12 +664,16 @@ namespace grb {
 			"use_index descriptor cannot be set if output vector is void" );
 
 		// check contract
-		if( size( x ) != size( y ) ) {
+		const size_t n = size( x );
+		if( n != size( y ) ) {
 			return MISMATCH;
 		}
-		if( size( x ) == 0 ) {
+		// check trivial op
+		// note: the below check cannot move after the check that uses getID
+		if( n == 0 ) {
 			return SUCCESS;
 		}
+		// continue contract checks
 		if( getID( x ) == getID( y ) ) {
 			return ILLEGAL;
 		}
@@ -697,15 +701,27 @@ namespace grb {
 		}
 
 		// get #nonzeroes
-		const size_t nz = internal::getCoordinates( y ).nonzeroes();
+		const size_t nz = nnz( y );
 #ifdef _DEBUG
 		std::cout << "grb::set called with source vector containing "
 			<< nz << " nonzeroes." << std::endl;
 #endif
 
+#ifndef NDEBUG
+		if( src == nullptr ) {
+			assert( dst == nullptr );
+		}
+#endif
 		// first copy contents
 		if( src == nullptr && dst == nullptr ) {
-			// then source is a pattern vector, just copy its pattern
+			// if both source and destination are dense void vectors, this is a no-op
+			if( (descr & descriptors::dense) || (
+					nnz( x ) == size( x ) && nz == size( y )
+				)
+			) {
+				return SUCCESS;
+			}
+			// otherwise, copy source nonzero pattern to destination:
 #ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp parallel
 			{
@@ -723,11 +739,11 @@ namespace grb {
 			}
 #endif
 		} else {
-#ifndef NDEBUG
-			if( src == nullptr ) {
-				assert( dst == nullptr );
+			// if the output is a void vector that is furthermore dense, then this is
+			// actually also a no-op:
+			if( (descr & descriptors::dense) && out_is_void ) {
+				return SUCCESS;
 			}
-#endif
 			// otherwise, the regular copy variant:
 #ifdef _H_GRB_REFERENCE_OMP_IO
 			#pragma omp parallel
@@ -739,8 +755,13 @@ namespace grb {
 				const size_t end = nz;
 #endif
 				for( size_t i = start; i < end; ++i ) {
-					const auto index = internal::getCoordinates( x ).asyncCopy(
-						internal::getCoordinates( y ), i );
+					size_t index;
+					if( !(descr & descriptors::dense) ) {
+						index = internal::getCoordinates( x ).asyncCopy(
+							internal::getCoordinates( y ), i );
+					} else {
+						index = start;
+					}
 					if( !out_is_void && !in_is_void ) {
 						dst[ index ] = internal::setIndexOrValue< descr, OutputType >(
 							index, src[ index ] );
@@ -752,7 +773,9 @@ namespace grb {
 		}
 
 		// set number of nonzeroes
-		internal::getCoordinates( x ).joinCopy( internal::getCoordinates( y ) );
+		if( !(descr & descriptors::dense) ) {
+			internal::getCoordinates( x ).joinCopy( internal::getCoordinates( y ) );
+		}
 
 		// done
 		return SUCCESS;


### PR DESCRIPTION
Previously, `grb::set` always accounted for sparsity in both source and destination. This MR exploits when `grb::descriptors::dense` is passed to `grb::set`, and makes sure to never read the input sparsity structure nor to write to the output sparsity structure. This is of course only valid in the unmasked case of `grb::set`.

Furthermore, this MR exploits the use of the dense descriptor if both the destination and source vectors are pattern vectors. Having such vectors that have a dense pattern, again in the unmasked case, makes the `grb::set` a no-op. The same applies when the destination vector is a pattern vector while the dense descriptor was given.

Finally, this MR moves forward an assertion check that if there is only one pattern vector, then this must be the destination vector -- it cannot be that the source is a pattern vector while the destination is not. This check previously was hidden in an if-else statement and wasn't very clear. To be complete-- this also pre-exists as a static-assert -- the moved check is one based on asserts instead, which guards against regressions and against invalid use by other backends.

As always, also a minor code style fix: rely on `grb::nnz` instead of internal coordinate functionality, since `grb::nnz` is now defined as a (cheap) getter function.