### PR TITLE
156 two grbewiseapply variants missing

### DIFF
--- a/include/graphblas/base/blas1.hpp
+++ b/include/graphblas/base/blas1.hpp
@@ -232,6 +232,90 @@ namespace grb {
 	}
 
 	/**
+	 * Computes \f$ z = \alpha \odot \beta \f$, out of place, operator and masked
+	 * version.
+	 *
+	 * @tparam descr      The descriptor to be used. Equal to
+	 *                    descriptors::no_operation if left unspecified.
+	 * @tparam OP         The operator to use.
+	 * @tparam InputType1 The value type of the left-hand vector.
+	 * @tparam InputType2 The value type of the right-hand scalar.
+	 * @tparam OutputType The value type of the ouput vector.
+	 * @tparam MaskType   The value type of the output mask vector.
+	 *
+	 * @param[out]  z   The output vector.
+	 * @param[in]  mask The ouptut mask.
+	 * @param[in] alpha The left-hand input scalar.
+	 * @param[in]  beta The right-hand input scalar.
+	 * @param[in]   op  The operator \f$ \odot \f$.
+	 * @param[in] phase  The #grb::Phase the call should execute. Optional; the
+	 *                   default parameter is #grb::EXECUTE.
+	 *
+	 * Specialisation scalar inputs, operator version. A call to this function
+	 * (with #grb::EXECUTE for \a phase) is equivalent to the following code:
+	 *
+	 * \code
+	 * typename OP::D3 tmp;
+	 * grb::apply( tmp, x, y, op );
+	 * grb::set( z, tmp );
+	 * \endcode
+	 *
+	 * @return #grb::SUCCESS  On successful completion of this call.
+	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 *                        capacity of \a z was insufficient. The output vector
+	 *                        \a z is cleared, and the call to this function has no
+	 *                        further effects.
+	 * @return #grb::OUTOFMEM If \a phase is #grb::RESIZE, indicates an
+	 *                        out-of-memory exception. The call to this function
+	 *                        shall have no other effects beyond returning this
+	 *                        error code; the previous state of \a z is retained.
+	 * @return #grb::PANIC    A general unmitigable error has been encountered. If
+	 *                        returned, ALP enters an undefined state and the user
+	 *                        program is encouraged to exit as quickly as possible.
+	 *
+	 * \par Performance semantics
+	 * Each backend must define performance semantics for this primitive.
+	 *
+	 * @see perfSemantics
+	 */
+	template<
+		Descriptor descr = descriptors::no_operation,
+		class OP, enum Backend backend,
+		typename OutputType, typename MaskType,
+		typename InputType1, typename InputType2,
+		typename Coords
+	>
+	RC eWiseApply(
+		Vector< OutputType, backend, Coords > &z,
+		const Vector< MaskType, backend, Coords > &mask,
+		const InputType1 alpha,
+		const InputType2 beta,
+		const OP &op = OP(),
+		const Phase &phase = EXECUTE,
+		const typename std::enable_if<
+			!grb::is_object< OutputType >::value &&
+			!grb::is_object< InputType1 >::value &&
+			!grb::is_object< InputType2 >::value &&
+			grb::is_operator< OP >::value, void
+		>::type * const = nullptr
+	) {
+#ifdef _DEBUG
+		std::cout << "In masked eWiseApply ([T1]<-T2<-T3), operator, base\n";
+#endif
+#ifndef NDEBUG
+		const bool should_not_call_eWiseApplyOpAMSS_base = false;
+		assert( should_not_call_eWiseApplyOpAMSS_base );
+#endif
+		(void) z;
+		(void) mask;
+		(void) alpha;
+		(void) beta;
+		(void) op;
+		(void) phase;
+		return UNSUPPORTED;
+	}
+
+	/**
 	 * Computes \f$ z = \alpha \odot \beta \f$, out of place, monoid version.
 	 *
 	 * @tparam descr      The descriptor to be used. Equal to
@@ -302,6 +386,90 @@ namespace grb {
 		assert( should_not_call_eWiseApplyMonASS_base );
 #endif
 		(void) z;
+		(void) alpha;
+		(void) beta;
+		(void) monoid;
+		(void) phase;
+		return UNSUPPORTED;
+	}
+
+	/**
+	 * Computes \f$ z = \alpha \odot \beta \f$, out of place, masked monoid
+	 * version.
+	 *
+	 * @tparam descr      The descriptor to be used. Equal to
+	 *                    descriptors::no_operation if left unspecified.
+	 * @tparam Monoid     The monoid to use.
+	 * @tparam InputType1 The value type of the left-hand vector.
+	 * @tparam InputType2 The value type of the right-hand scalar.
+	 * @tparam OutputType The value type of the ouput vector.
+	 * @tparam MaskType   The value type of the output mask vector.
+	 *
+	 * @param[out]  z    The output vector.
+	 * @param[in]  mask  The output mask.
+	 * @param[in]  alpha The left-hand input scalar.
+	 * @param[in]  beta  The right-hand input scalar.
+	 * @param[in] monoid The monoid with underlying operator \f$ \odot \f$.
+	 * @param[in] phase  The #grb::Phase the call should execute. Optional; the
+	 *                   default parameter is #grb::EXECUTE.
+	 *
+	 * Specialisation scalar inputs, monoid version. A call to this function
+	 * (with #grb::EXECUTE for \a phase) is equivalent to the following code:
+	 *
+	 * \code
+	 * typename OP::D3 tmp;
+	 * grb::apply( tmp, x, y, monoid.getOperator() );
+	 * grb::set( z, tmp );
+	 * \endcode
+	 *
+	 * @return #grb::SUCCESS  On successful completion of this call.
+	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 *                        capacity of \a z was insufficient. The output vector
+	 *                        \a z is cleared, and the call to this function has no
+	 *                        further effects.
+	 * @return #grb::OUTOFMEM If \a phase is #grb::RESIZE, indicates an
+	 *                        out-of-memory exception. The call to this function
+	 *                        shall have no other effects beyond returning this
+	 *                        error code; the previous state of \a z is retained.
+	 * @return #grb::PANIC    A general unmitigable error has been encountered. If
+	 *                        returned, ALP enters an undefined state and the user
+	 *                        program is encouraged to exit as quickly as possible.
+	 *
+	 * \par Performance semantics
+	 * Each backend must define performance semantics for this primitive.
+	 *
+	 * @see perfSemantics
+	 */
+	template<
+		Descriptor descr = descriptors::no_operation,
+		class Monoid, enum Backend backend,
+		typename OutputType, typename MaskType,
+		typename InputType1, typename InputType2,
+		typename Coords
+	>
+	RC eWiseApply(
+		Vector< OutputType, backend, Coords > &z,
+		const Vector< MaskType, backend, Coords > &mask,
+		const InputType1 alpha,
+		const InputType2 beta,
+		const Monoid &monoid = Monoid(),
+		const Phase &phase = EXECUTE,
+		const typename std::enable_if<
+			!grb::is_object< OutputType >::value &&
+			!grb::is_object< InputType1 >::value &&
+			!grb::is_object< InputType2 >::value &&
+			grb::is_monoid< Monoid >::value, void
+		>::type * const = nullptr
+	) {
+#ifdef _DEBUG
+		std::cout << "In masked eWiseApply ([T1]<-T2<-T3), monoid, base\n";
+#endif
+#ifndef NDEBUG
+		const bool should_not_call_eWiseApplyMonAMSS_base = false;
+		assert( should_not_call_eWiseApplyMonAMSS_base );
+#endif
+		(void) z;
+		(void) mask;
 		(void) alpha;
 		(void) beta;
 		(void) monoid;

--- a/include/graphblas/nonblocking/blas1.hpp
+++ b/include/graphblas/nonblocking/blas1.hpp
@@ -4733,6 +4733,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-[T2]<-T3), operator variant\n";
 #endif
@@ -4909,6 +4922,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-T3), operator variant\n";
 #endif
@@ -5015,6 +5041,19 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-T3), monoid variant\n";
 #endif
@@ -5091,6 +5130,22 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-T3, using operator)\n";
 #endif
@@ -5288,6 +5343,19 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-[T2]<-[T3], using monoid)\n";
 #endif
@@ -5449,6 +5517,19 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-T2<-[T3], using monoid)\n";
 #endif
@@ -5604,6 +5685,19 @@ namespace grb {
 				grb::is_monoid< Monoid >::value,
 			void >::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-[T2]<-T3, using monoid)\n";
 #endif
@@ -5765,6 +5859,22 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-[T3], using monoid)\n";
 #endif
@@ -6020,6 +6130,22 @@ namespace grb {
 				grb::is_monoid< Monoid >::value,
 			void >::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-[T3], using monoid)\n";
 #endif
@@ -6203,6 +6329,22 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-T3, using monoid)\n";
 #endif
@@ -6382,6 +6524,19 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-[T3]), operator variant\n";
 #endif
@@ -6559,6 +6714,22 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-[T3], operator variant)\n";
 #endif
@@ -6752,6 +6923,19 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-[T2]<-[T3]), operator variant\n";
 #endif
@@ -6955,6 +7139,22 @@ namespace grb {
 			void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-[T3], using operator)\n";
 #endif

--- a/include/graphblas/reference/blas1.hpp
+++ b/include/graphblas/reference/blas1.hpp
@@ -4000,6 +4000,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-[T2]<-T3), operator variant\n";
 #endif
@@ -4071,6 +4084,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-T3), operator variant\n";
 #endif
@@ -4115,6 +4141,22 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-T3), operator variant\n";
 #endif
@@ -4169,6 +4211,19 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-T3), monoid variant\n";
 #endif
@@ -4202,6 +4257,22 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-T3), monoid variant\n";
 #endif
@@ -4236,6 +4307,22 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-T3, using operator)\n";
 #endif
@@ -4325,6 +4412,19 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-[T2]<-[T3], using monoid)\n";
 #endif
@@ -4400,6 +4500,19 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-T2<-[T3], using monoid)\n";
 #endif
@@ -4465,6 +4578,19 @@ namespace grb {
 				grb::is_monoid< Monoid >::value,
 			void >::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
 #ifdef _DEBUG
 		std::cout << "In unmasked eWiseApply ([T1]<-[T2]<-T3, using monoid)\n";
 #endif
@@ -4533,6 +4659,22 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-[T3], using monoid)\n";
 #endif
@@ -4651,6 +4793,22 @@ namespace grb {
 			grb::is_monoid< Monoid >::value,
 		void >::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-[T3], using monoid)\n";
 #endif
@@ -4731,6 +4889,22 @@ namespace grb {
 			grb::is_monoid< Monoid >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename Monoid::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given monoid" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-T3, using monoid)\n";
 #endif
@@ -4825,6 +4999,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-T2<-[T3]), operator variant\n";
 #endif
@@ -4904,6 +5091,22 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-T2<-[T3], operator variant)\n";
 #endif
@@ -5009,6 +5212,19 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
 #ifdef _DEBUG
 		std::cout << "In eWiseApply ([T1]<-[T2]<-[T3]), operator variant\n";
 #endif
@@ -5128,6 +5344,22 @@ namespace grb {
 			grb::is_operator< OP >::value, void
 		>::type * const = nullptr
 	) {
+		// static checks
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D1, InputType1 >::value ), "grb::eWiseApply",
+			"called with a left-hand input element type that does not match the "
+			"first domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D2, InputType2 >::value ), "grb::eWiseApply",
+			"called with a right-hand input element type that does not match the "
+			"second domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< typename OP::D3, OutputType >::value ), "grb::eWiseApply",
+			"called with an output element type that does not match the "
+			"third domain of the given operator" );
+		NO_CAST_OP_ASSERT( ( !(descr & descriptors::no_casting) ||
+			std::is_same< bool, MaskType >::value ), "grb::eWiseApply",
+			"called with an output mask element type that is not Boolean " );
 #ifdef _DEBUG
 		std::cout << "In masked eWiseApply ([T1]<-[T2]<-[T3], using operator)\n";
 #endif

--- a/tests/unit/ewiseapply.cpp
+++ b/tests/unit/ewiseapply.cpp
@@ -21,8 +21,6 @@
 #include <graphblas.hpp>
 
 
-using namespace grb;
-
 void grb_program( const size_t &n, grb::RC &rc ) {
 	grb::Vector< double > out( n ), left( n ), right( n );
 	grb::Vector< bool > mask( n );
@@ -51,7 +49,8 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 			}
 		}, temp );
 	rc = rc ? rc : grb::set( mask, temp, true );
-	if( rc != SUCCESS ) {
+	rc = rc ? rc : grb::wait();
+	if( rc != grb::SUCCESS ) {
 		std::cerr << "\tinitialisation FAILED\n";
 		return;
 	}
@@ -59,67 +58,70 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	grb::Monoid< grb::operators::add< double >, grb::identities::zero > plusM;
 
 	// test operator versions first, dense vectors only, without masks
+	// [double] <- [double] <- double (OP, no mask)
 	rc = grb::eWiseApply( out, left, 0.25, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << " ), "
-				<< "expected " << size( out ) << " ) at subtest 1\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
+				<< "expected " << grb::size( out ) << " ) at subtest 1\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", "
 					<< pair.second << " ); expected ( " << pair.first << ", 1.75 ) "
 					<< "at subtest 1\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (OP, no mask)
 	rc = grb::eWiseApply( out, 0.25, left, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) << " ) at subtest 2\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest 2\n";
+			rc = grb::FAILED;
 		}
 		for( const auto pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 2\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (OP, no mask)
 	rc = grb::eWiseApply( out, left, left, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) << " ) at subtest 3\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest 3\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != static_cast< double >( 3 ) ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected ( " << pair.first << ", 3 ) at subtest 3\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -127,85 +129,88 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// operator versions, dense vectors only, with masks
+	// [double] <- [double] <- double (OP, masked)
 	rc = grb::eWiseApply( out, mask, left, 0.25, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 4\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest 4\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 					return;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< " ); expected this index to be empty) at subtest 4\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (OP, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, left, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 5\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 5\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected this index to be empty) at subtest 5\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (OP, masked)
 	rc = grb::eWiseApply( out, mask, left, left, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 6\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != static_cast< double >( 3 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 3 ) at subtest 6\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected this index to be empty) at subtest 6\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -213,66 +218,69 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// monoid version, dense vectors, unmasked
+	// [double] <- [double] <- double (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, 0.25, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) << " ) at subtest 7\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest 7\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 7\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, 0.25, left, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) << " ) at subtest 8\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest 8\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 8\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
-	rc = grb::eWiseApply( out, left, left, plusM.getOperator() );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out )
-				<< ", expected " << size( out ) << " ) at subtest 9\n";
-			rc = FAILED;
+	// [double] <- [double] <- [double] (Monoid, no mask)
+	rc = grb::eWiseApply( out, left, left, plusM );
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
+				<< ", expected " << grb::size( out ) << " ) at subtest 9\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != static_cast< double >( 3 ) ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected ( " << pair.first << ", 3 ) at subtest 9\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -280,84 +288,87 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// monoid versions, dense vectors, with masks
+	// [double] <- [double] <- double (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, left, 0.25, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 10\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 10\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected this index to be empty) at subtest 10\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, left, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 11\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 11\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected this index to be empty) at subtest 11\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, left, left, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
 				<< " != " << grb::nnz( mask ) << " ) at subtest 12\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != static_cast< double >( 3 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 3 ) at subtest 12\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected this index to be empty) at subtest 12\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -365,148 +376,153 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// monoid version, sparse vectors, unmasked
+	// [double] <- [double] <- double (Monoid, no mask)
 	rc = grb::eWiseApply( out, right, 0.25, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) << " ) at subtest 13\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest 13\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != 0.5 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 0.5 ) at subtest 13\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != 0.25 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 0.25 ) at subtest 13\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, 0.25, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << " ), "
-				<< "expected " << size( out ) << " ) at subtest 14\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
+				<< "expected " << grb::size( out ) << " ) at subtest 14\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != 0.5 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ); expected ( " << pair.first << ", 0.5 ) at subtest 14\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != 0.25 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ); expected ( " << pair.first << ", 0.25 ) at subtest 14\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << " ), "
-				<< "expected " << size( out ) << " ) at subtest 15\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
+				<< "expected " << grb::size( out ) << " ) at subtest 15\n";
+			rc = grb::FAILED;
 		}
 		for( const auto pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( 1.75 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest 15\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != static_cast< double >( 1.5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ); expected ( " << pair.first << ", 1.5 ) at subtest 15\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, right, left, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( right ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( right ) << " ) at subtest 16\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( right ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( right ) << " ) at subtest 16\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( 1.75 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 16\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != static_cast< double >( 1.5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 1.5 ) at subtest 16\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, right, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != nnz( right ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << nnz( right ) << " ) at subtest 17\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::nnz( right ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::nnz( right ) << " ) at subtest 17\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( .5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< "; expected ( " << pair.first << ", 0.5 ) at subtest 17\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected nothing at this entry) at subtest 17\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -514,13 +530,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	// monoid version, sparse vectors, with masks
+	// [double] <- [double] <- double (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, right, 0.25, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) / 2 ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-			       << "expected " << size( out ) / 2 << " ) at subtest 18\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+			       << "expected " << grb::size( out ) / 2 << " ) at subtest 18\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
@@ -528,35 +545,36 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 					if( pair.second != 0.5 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 0.5 ) at subtest 18\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != 0.25 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 0.25 ) at subtest 18\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected nothing at this index) at subtest 18\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- double <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) / 2 ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) / 2 << " ) at subtest 19\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) / 2 << " ) at subtest 19\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
@@ -564,35 +582,36 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 					if( pair.second != 0.5 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 0.5 ) at subtest 19\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != 0.25 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 0.25 ) at subtest 19\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected nothing at this index) at subtest 19\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, left, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( out ) / 2 ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( out ) / 2 << " ) at subtest 20\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) / 2 << " ) at subtest 20\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
@@ -600,35 +619,36 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 					if( pair.second != static_cast< double >( 1.75 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 1.75 ) at subtest 20\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != static_cast< double >( 1.5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 1.5 ) at subtest 20\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected nothing at this index) at subtest 20\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, right, left, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != size( right ) / 2 ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
-				<< "expected " << size( right ) / 2 << " ) at subtest 21\n";
-			rc = FAILED;
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( right ) / 2 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( right ) / 2 << " ) at subtest 21\n";
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
@@ -636,37 +656,38 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 					if( pair.second != static_cast< double >( 1.75 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 1.75 ) at subtest 21\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != static_cast< double >( 1.5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< "; expected ( " << pair.first << ", 1.5 ) at subtest 21\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< "; expected nothing at this index) at subtest 21\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, right, right, plusM );
-	assert( rc == SUCCESS );
+	assert( rc == grb::SUCCESS );
 	const bool halfIsOdd = ((n / 2) % 2) == 1;
-	if( rc == SUCCESS ) {
-		const size_t expected = nnz( right ) / 2 + (halfIsOdd ? 1 : 0);
-		if( nnz( out ) != expected ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
+	if( rc == grb::SUCCESS ) {
+		const size_t expected = grb::nnz( right ) / 2 + (halfIsOdd ? 1 : 0);
+		if( grb::nnz( out ) != expected ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
 				<< "expected " << expected << " ) at subtest 22\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
@@ -674,26 +695,27 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 					if( pair.second != static_cast< double >( .5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 							<< " ), expected ( " << pair.first << ", 0.5 ) at subtest 22\n";
-						rc = FAILED;
+						rc = grb::FAILED;
 					}
 				} else {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ), expected nothing at this entry at subtest 22\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< " ), expected nothing at this index at subtest 22\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = clear( right );
 	rc = rc ? rc : clear( left );
 	rc = rc ? rc : setElement( right, 2.17, 0 );
@@ -703,69 +725,70 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	rc = rc ? rc : setElement( left, -1.0, 0 );
 	rc = eWiseApply( out, mask, left, right, plusM );
 	assert( n % 2 == 0 );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
 		const size_t expect = 1;
-		if( nnz( out ) != expect ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
+		if( grb::nnz( out ) != expect ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
 				<< "), expected " << expect << " ) at subtest 23\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first == 0 ) {
 				if( pair.second != 1.17 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 23\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< " ), expected ( " << pair.first << ", " << (n/2) << " ) "
 					<< "at subtest 23\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
 		return;
 	}
 
+	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, right, plusM );
-	assert( rc == SUCCESS );
-	if( rc == SUCCESS ) {
-		if( nnz( out ) != 3 ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << nnz( out ) << ", "
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != 3 ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
 				<< "expected " << 3 << " ) at subtest 24\n";
-			rc = FAILED;
+			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first == 0 ) {
 				if( pair.second != 1.17 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 24\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else if( pair.first == n / 2 ) {
 				if( pair.second != 2.0 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ), expected ( " << pair.first << ", 2.0 ) at subtest 24\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else if( pair.first == n - 1 ) {
-				if( !utils::equals( pair.second, 4.14, 1 ) ) {
+				if( !grb::utils::equals( pair.second, 4.14, 1 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 						<< " ), expected ( " << pair.first << ", 4.14 ) at subtest 24\n";
-					rc = FAILED;
+					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< ", expected nothing at this index at subtest 24\n";
-				rc = FAILED;
+				rc = grb::FAILED;
 			}
 		}
-		if( rc == FAILED ) {
+		if( rc == grb::FAILED ) {
 			return;
 		}
 	} else {
@@ -809,13 +832,13 @@ int main( int argc, char ** argv ) {
 	}
 
 	std::cout << "This is functional test " << argv[ 0 ] << "\n";
-	grb::Launcher< AUTOMATIC > launcher;
+	grb::Launcher< grb::AUTOMATIC > launcher;
 	grb::RC out;
-	if( launcher.exec( &grb_program, in, out, true ) != SUCCESS ) {
+	if( launcher.exec( &grb_program, in, out, true ) != grb::SUCCESS ) {
 		std::cerr << "Launching test FAILED\n";
 		return 255;
 	}
-	if( out != SUCCESS ) {
+	if( out != grb::SUCCESS ) {
 		std::cerr << std::flush;
 		std::cout << "Test FAILED (" << grb::toString( out ) << ")" << std::endl;
 	} else {

--- a/tests/unit/ewiseapply.cpp
+++ b/tests/unit/ewiseapply.cpp
@@ -56,22 +56,23 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	}
 
 	grb::Monoid< grb::operators::add< double >, grb::identities::zero > plusM;
+	unsigned int test = 1;
 
 	// test operator versions first, dense vectors only, without masks
-	// [double] <- [double] <- double (OP, no mask)
-	rc = grb::eWiseApply( out, left, 0.25, plusM.getOperator() );
+	// [double] <- double <- double (OP, no mask)
+	rc = grb::eWiseApply( out, 0.25, 0.25, plusM.getOperator() );
 	assert( rc == grb::SUCCESS );
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
-			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
-				<< "expected " << grb::size( out ) << " ) at subtest 1\n";
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
+				<< "), expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
-			if( pair.second != 1.75 ) {
-				std::cerr << "\tunexpected entry ( " << pair.first << ", "
-					<< pair.second << " ); expected ( " << pair.first << ", 1.75 ) "
-					<< "at subtest 1\n";
+			if( pair.second != 0.5 ) {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< " ); expected ( " << pair.first << ", 0.5 ) at subtest " << test
+					<< "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -81,6 +82,32 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
+
+	// [double] <- [double] <- double (OP, no mask)
+	rc = grb::eWiseApply( out, left, 0.25, plusM.getOperator() );
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
+			rc = grb::FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.second != 1.75 ) {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", "
+					<< pair.second << " ); expected ( " << pair.first << ", 1.75 ) "
+					<< "at subtest " << test << "1\n";
+				rc = grb::FAILED;
+			}
+		}
+		if( rc == grb::FAILED ) {
+			return;
+		}
+	} else {
+		return;
+	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (OP, no mask)
 	rc = grb::eWiseApply( out, 0.25, left, plusM.getOperator() );
@@ -88,13 +115,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) << " ) at subtest 2\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 2\n";
+					<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+					<< "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -104,6 +132,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (OP, no mask)
 	rc = grb::eWiseApply( out, left, left, plusM.getOperator() );
@@ -111,13 +140,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) << " ) at subtest 3\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != static_cast< double >( 3 ) ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected ( " << pair.first << ", 3 ) at subtest 3\n";
+					<< "; expected ( " << pair.first << ", 3 ) at subtest " << test
+					<< "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -127,28 +157,61 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// operator versions, dense vectors only, with masks
+	// [double] <- double <- double (OP, masked)
+	rc = grb::eWiseApply( out, mask, 0.25, 0.25, plusM.getOperator() );
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::nnz( mask ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
+			rc = grb::FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.first < n / 2 ) {
+				if( pair.second != 0.5 ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< " ); expected ( " << pair.first << ", 0.5 ) at subtest " << test
+						<< "\n";
+					rc = grb::FAILED;
+				}
+			} else {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< " ); expected no entry at this position at subtest " << test << "\n";
+				rc = grb::FAILED;
+			}
+			if( rc == grb::FAILED ) {
+				return;
+			}
+		}
+	} else {
+		return;
+	}
+	(void) ++test;
+
 	// [double] <- [double] <- double (OP, masked)
 	rc = grb::eWiseApply( out, mask, left, 0.25, plusM.getOperator() );
 	assert( rc == grb::SUCCESS );
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< " != " << grb::nnz( mask ) << " ) at subtest 4\n";
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest 4\n";
+						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 					return;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< " ); expected this index to be empty) at subtest 4\n";
+					<< " ); expected no entry at this index at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -158,6 +221,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (OP, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, left, plusM.getOperator() );
@@ -165,19 +229,20 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< " != " << grb::nnz( mask ) << " ) at subtest 5\n";
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 5\n";
+						<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected this index to be empty) at subtest 5\n";
+					<< "; expected this index to be empty) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -187,6 +252,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (OP, masked)
 	rc = grb::eWiseApply( out, mask, left, left, plusM.getOperator() );
@@ -194,19 +260,20 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< " != " << grb::nnz( mask ) << " ) at subtest 6\n";
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != static_cast< double >( 3 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 3 ) at subtest 6\n";
+						<< "; expected ( " << pair.first << ", 3 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected this index to be empty) at subtest 6\n";
+					<< "; expected this index to be empty) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -216,21 +283,48 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// monoid version, dense vectors, unmasked
+	// [double] <- double <- double (Monoid, no mask)
+	rc = grb::eWiseApply( out, 0.25, 0.25, plusM );
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::size( out ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
+			rc = grb::FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.second != 0.5 ) {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< " ); expected ( " << pair.first << ", 0.5 ) at subtest " << test
+					<< "\n";
+				rc = grb::FAILED;
+			}
+		}
+		if( rc == grb::FAILED ) {
+			return;
+		}
+	} else {
+		return;
+	}
+	(void) ++test;
+
 	// [double] <- [double] <- double (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, 0.25, plusM );
 	assert( rc == grb::SUCCESS );
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) << " ) at subtest 7\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 7\n";
+					<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+					<< "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -240,6 +334,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, 0.25, left, plusM );
@@ -247,13 +342,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) << " ) at subtest 8\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != 1.75 ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected ( " << pair.first << ", 1.75 ) at subtest 8\n";
+					<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+					<< "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -263,6 +359,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, left, plusM );
@@ -270,13 +367,13 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< ", expected " << grb::size( out ) << " ) at subtest 9\n";
+				<< ", expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.second != static_cast< double >( 3 ) ) {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected ( " << pair.first << ", 3 ) at subtest 9\n";
+					<< "; expected ( " << pair.first << ", 3 ) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -286,10 +383,11 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// monoid versions, dense vectors, with masks
-	// [double] <- [double] <- double (Monoid, masked)
-	rc = grb::eWiseApply( out, mask, left, 0.25, plusM );
+	// [double] <- double <- double (Monoid, masked)
+	rc = grb::eWiseApply( out, mask, 0.25, 0.25, plusM );
 	assert( rc == grb::SUCCESS );
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
@@ -299,14 +397,14 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
-				if( pair.second != 1.75 ) {
+				if( pair.second != .5 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 10\n";
+						<< "; expected ( " << pair.first << ", 0.5 ) at subtest " << test << "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected this index to be empty) at subtest 10\n";
+					<< "; expected this index to be empty) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -316,6 +414,38 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
+
+	// [double] <- [double] <- double (Monoid, masked)
+	rc = grb::eWiseApply( out, mask, left, 0.25, plusM );
+	assert( rc == grb::SUCCESS );
+	if( rc == grb::SUCCESS ) {
+		if( grb::nnz( out ) != grb::nnz( mask ) ) {
+			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
+			rc = grb::FAILED;
+		}
+		for( const auto &pair : out ) {
+			if( pair.first < n / 2 ) {
+				if( pair.second != 1.75 ) {
+					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+						<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "\n";
+					rc = grb::FAILED;
+				}
+			} else {
+				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
+					<< "; expected this index to be empty) at subtest " << test << "\n";
+				rc = grb::FAILED;
+			}
+		}
+		if( rc == grb::FAILED ) {
+			return;
+		}
+	} else {
+		return;
+	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, left, plusM );
@@ -323,19 +453,20 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< " != " << grb::nnz( mask ) << " ) at subtest 11\n";
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != 1.75 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 11\n";
+						<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "11\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected this index to be empty) at subtest 11\n";
+					<< "; expected this index to be empty) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -345,6 +476,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, left, left, plusM );
@@ -352,19 +484,20 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( mask ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out )
-				<< " != " << grb::nnz( mask ) << " ) at subtest 12\n";
+				<< " != " << grb::nnz( mask ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first < n / 2 ) {
 				if( pair.second != static_cast< double >( 3 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 3 ) at subtest 12\n";
+						<< "; expected ( " << pair.first << ", 3 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected this index to be empty) at subtest 12\n";
+					<< "; expected this index to be empty) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -374,6 +507,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// monoid version, sparse vectors, unmasked
 	// [double] <- [double] <- double (Monoid, no mask)
@@ -382,20 +516,22 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) << " ) at subtest 13\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != 0.5 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 0.5 ) at subtest 13\n";
+						<< "; expected ( " << pair.first << ", 0.5 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != 0.25 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 0.25 ) at subtest 13\n";
+						<< "; expected ( " << pair.first << ", 0.25 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			}
@@ -406,6 +542,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, 0.25, right, plusM );
@@ -413,20 +550,22 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
-				<< "expected " << grb::size( out ) << " ) at subtest 14\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != 0.5 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ); expected ( " << pair.first << ", 0.5 ) at subtest 14\n";
+						<< " ); expected ( " << pair.first << ", 0.5 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != 0.25 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ); expected ( " << pair.first << ", 0.25 ) at subtest 14\n";
+						<< " ); expected ( " << pair.first << ", 0.25 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			}
@@ -437,6 +576,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, right, plusM );
@@ -444,20 +584,22 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << " ), "
-				<< "expected " << grb::size( out ) << " ) at subtest 15\n";
+				<< "expected " << grb::size( out ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( 1.75 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest 15\n";
+						<< " ); expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != static_cast< double >( 1.5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ); expected ( " << pair.first << ", 1.5 ) at subtest 15\n";
+						<< " ); expected ( " << pair.first << ", 1.5 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			}
@@ -468,6 +610,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, right, left, plusM );
@@ -475,20 +618,22 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( right ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( right ) << " ) at subtest 16\n";
+				<< "expected " << grb::size( right ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( 1.75 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 1.75 ) at subtest 16\n";
+						<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				if( pair.second != static_cast< double >( 1.5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 1.5 ) at subtest 16\n";
+						<< "; expected ( " << pair.first << ", 1.5 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			}
@@ -499,6 +644,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, right, right, plusM );
@@ -506,19 +652,19 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::nnz( right ) ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::nnz( right ) << " ) at subtest 17\n";
+				<< "expected " << grb::nnz( right ) << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first % 2 == 0 ) {
 				if( pair.second != static_cast< double >( .5 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< "; expected ( " << pair.first << ", 0.5 ) at subtest 17\n";
+						<< "; expected ( " << pair.first << ", 0.5 ) at subtest " << test << "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this entry) at subtest 17\n";
+					<< "; expected nothing at this entry) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -528,6 +674,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// monoid version, sparse vectors, with masks
 	// [double] <- [double] <- double (Monoid, masked)
@@ -536,7 +683,8 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-			       << "expected " << grb::size( out ) / 2 << " ) at subtest 18\n";
+			       << "expected " << grb::size( out ) / 2 << " ) at subtest " << test
+			       << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
@@ -544,19 +692,21 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != 0.5 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 0.5 ) at subtest 18\n";
+							<< "; expected ( " << pair.first << ", 0.5 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != 0.25 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 0.25 ) at subtest 18\n";
+							<< "; expected ( " << pair.first << ", 0.25 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this index) at subtest 18\n";
+					<< "; expected nothing at this index) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -566,6 +716,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- double <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, 0.25, right, plusM );
@@ -573,7 +724,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) / 2 << " ) at subtest 19\n";
+				<< "expected " << grb::size( out ) / 2 << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
@@ -581,19 +732,21 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != 0.5 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 0.5 ) at subtest 19\n";
+							<< "; expected ( " << pair.first << ", 0.5 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != 0.25 ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 0.25 ) at subtest 19\n";
+							<< "; expected ( " << pair.first << ", 0.25 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this index) at subtest 19\n";
+					<< "; expected nothing at this index) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -603,6 +756,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, left, right, plusM );
@@ -610,7 +764,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( out ) / 2 ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( out ) / 2 << " ) at subtest 20\n";
+				<< "expected " << grb::size( out ) / 2 << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
@@ -618,19 +772,21 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != static_cast< double >( 1.75 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 1.75 ) at subtest 20\n";
+							<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != static_cast< double >( 1.5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 1.5 ) at subtest 20\n";
+							<< "; expected ( " << pair.first << ", 1.5 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this index) at subtest 20\n";
+					<< "; expected nothing at this index) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -640,6 +796,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, right, left, plusM );
@@ -647,7 +804,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != grb::size( right ) / 2 ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << grb::size( right ) / 2 << " ) at subtest 21\n";
+				<< "expected " << grb::size( right ) / 2 << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
@@ -655,19 +812,21 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != static_cast< double >( 1.75 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 1.75 ) at subtest 21\n";
+							<< "; expected ( " << pair.first << ", 1.75 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				} else {
 					if( pair.second != static_cast< double >( 1.5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< "; expected ( " << pair.first << ", 1.5 ) at subtest 21\n";
+							<< "; expected ( " << pair.first << ", 1.5 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< "; expected nothing at this index) at subtest 21\n";
+					<< "; expected nothing at this index) at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -677,6 +836,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = grb::eWiseApply( out, mask, right, right, plusM );
@@ -686,7 +846,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		const size_t expected = grb::nnz( right ) / 2 + (halfIsOdd ? 1 : 0);
 		if( grb::nnz( out ) != expected ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << expected << " ) at subtest 22\n";
+				<< "expected " << expected << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
@@ -694,17 +854,18 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 				if( pair.first % 2 == 0 ) {
 					if( pair.second != static_cast< double >( .5 ) ) {
 						std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-							<< " ), expected ( " << pair.first << ", 0.5 ) at subtest 22\n";
+							<< " ), expected ( " << pair.first << ", 0.5 ) at subtest " << test
+							<< "\n";
 						rc = grb::FAILED;
 					}
 				} else {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ), expected nothing at this entry at subtest 22\n";
+						<< " ), expected nothing at this entry at subtest " << test << "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< " ), expected nothing at this index at subtest 22\n";
+					<< " ), expected nothing at this index at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -714,6 +875,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, masked)
 	rc = clear( right );
@@ -723,6 +885,12 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	rc = rc ? rc : setElement( right, 3.14, n-1 );
 	rc = rc ? rc : setElement( left,  1.0, n-1 );
 	rc = rc ? rc : setElement( left, -1.0, 0 );
+	rc = rc ? rc : grb::wait();
+	if( rc != grb::SUCCESS ) {
+		std::cerr << "\tre-initialisation for further tests with sparse vectors "
+			<< "FAILED\n";
+		return;
+	}
 	rc = eWiseApply( out, mask, left, right, plusM );
 	assert( n % 2 == 0 );
 	assert( rc == grb::SUCCESS );
@@ -730,20 +898,21 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 		const size_t expect = 1;
 		if( grb::nnz( out ) != expect ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "), expected " << expect << " ) at subtest 23\n";
+				<< "), expected " << expect << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first == 0 ) {
 				if( pair.second != 1.17 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 23\n";
+						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
 					<< " ), expected ( " << pair.first << ", " << (n/2) << " ) "
-					<< "at subtest 23\n";
+					<< "at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -753,6 +922,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// [double] <- [double] <- [double] (Monoid, no mask)
 	rc = grb::eWiseApply( out, left, right, plusM );
@@ -760,31 +930,34 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	if( rc == grb::SUCCESS ) {
 		if( grb::nnz( out ) != 3 ) {
 			std::cerr << "\tunexpected number of nonzeroes ( " << grb::nnz( out ) << ", "
-				<< "expected " << 3 << " ) at subtest 24\n";
+				<< "expected " << 3 << " ) at subtest " << test << "\n";
 			rc = grb::FAILED;
 		}
 		for( const auto &pair : out ) {
 			if( pair.first == 0 ) {
 				if( pair.second != 1.17 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest 24\n";
+						<< " ), expected ( " << pair.first << ", 1.17 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else if( pair.first == n / 2 ) {
 				if( pair.second != 2.0 ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ), expected ( " << pair.first << ", 2.0 ) at subtest 24\n";
+						<< " ), expected ( " << pair.first << ", 2.0 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else if( pair.first == n - 1 ) {
 				if( !grb::utils::equals( pair.second, 4.14, 1 ) ) {
 					std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-						<< " ), expected ( " << pair.first << ", 4.14 ) at subtest 24\n";
+						<< " ), expected ( " << pair.first << ", 4.14 ) at subtest " << test
+						<< "\n";
 					rc = grb::FAILED;
 				}
 			} else {
 				std::cerr << "\tunexpected entry ( " << pair.first << ", " << pair.second
-					<< ", expected nothing at this index at subtest 24\n";
+					<< ", expected nothing at this index at subtest " << test << "\n";
 				rc = grb::FAILED;
 			}
 		}
@@ -794,6 +967,7 @@ void grb_program( const size_t &n, grb::RC &rc ) {
 	} else {
 		return;
 	}
+	(void) ++test;
 
 	// those were all variants:)
 }


### PR DESCRIPTION
The masked eWiseApply with two scalar inputs was missing for both the operator and monoid variants. Additionally, unit tests for all variants of eWiseApply with two scalar inputs were missing. This MR addresses both issues, and additionally enables previously missing static checks for all eWiseApply variants, as well as fixes minor code style issues.