### PR TITLE
622 tests depending on datasets are skipped

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,25 @@ stages:
   - centos-test-and-install
 
 
+variables:
+  IS_MAIN_PIPELINE: "no"
+
+workflow:
+  rules:
+  # the following rules trigger after new commits are merged on master, develop or a version/rc branch
+    - if: $CI_COMMIT_BRANCH == "master"
+      variables:
+        IS_MAIN_PIPELINE: "yes"
+    - if: $CI_COMMIT_BRANCH == "develop"
+      variables:
+        IS_MAIN_PIPELINE: "yes"
+    - if: $CI_COMMIT_BRANCH =~ /^v.*-rc.*$/
+      variables:
+        IS_MAIN_PIPELINE: "yes"
+# trigger pipeline in any case
+    - when: always
+
+
 # Build / test / install on CentOS 8, only for main branches
 
 #build_centos_8:
@@ -119,8 +138,11 @@ stages:
 
 build_test:
   stage: build-and-secrets
+  rules:
   script:
-    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-lpf=${LPF_PATH} && make -j$(nproc) build_tests_all
+# if we are on master develop or v/-rc branch (or attempting to merge onto them), then also trigger LPF-related tests
+    - if [ "${IS_MAIN_PIPELINE}" == "yes" ]; then LPF_SWITCH="--with-lpf=${LPF_PATH}"; fi
+    - mkdir -p install build && cd ./build && ../bootstrap.sh ${LPF_SWITCH} --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
     - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
   artifacts:
     paths:
@@ -137,16 +159,18 @@ build_debug2_tests:
   stage: debug-build
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Debug ../ && make -j$(nproc) build_tests_all
+  dependencies: []
 
 
 build_debugrelease_tests:
   stage: build-and-secrets
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
-  only:
-    - master
-    - develop
-    - /^v.*-rc.*$/
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  dependencies: []
 
 
 # linting is currently disabled since clang-format is not mature enough
@@ -170,6 +194,7 @@ tests_unit:
   script:
     - cd ./build && make -j$(nproc) tests_unit &> unittests.log
     - ../tests/summarise.sh unittests.log
+  dependencies: [build_test]
 
 
 tests_smoke:
@@ -177,18 +202,20 @@ tests_smoke:
   script:
     - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
     - ../tests/summarise.sh smoketests.log
-
+  dependencies: [build_test]
 
 test_installation:
   stage: test-and-install
   script:
     - cd ./build && make -j$(nproc) install
+  dependencies: [build_test]
 
 
-build_debug:
+build_test_debug:
   stage: debug-build
   script:
-    - rm -rf build install && mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
+    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
+    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
   artifacts:
     paths:
       - build/
@@ -196,6 +223,7 @@ build_debug:
       - build/**/*.o
       - build/**/*.o.d
     expire_in: 43 minutes
+  dependencies: []
 
 
 test_smoke_debug:
@@ -203,12 +231,13 @@ test_smoke_debug:
   script:
     - cd ./build && make -j$(nproc) smoketests &> smoketests.log
     - ../tests/summarise.sh smoketests.log
-
+  dependencies: [build_test_debug]
 
 test_install_debug:
   stage: debug-test
   script:
     - cd ./build && make -j$(nproc) install
+  dependencies: [build_test_debug]
 
 
 gitleaks:
@@ -222,23 +251,24 @@ gitleaks:
 ## Additional tests specific to main branches only
 
 tests_performance:
-   stage: test-and-install
-   script:
-     - cd ./build && make -j$(nproc) performancetests &> performancetests.log
-     - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
-   only:
-     - master
-     - develop
-     - /^v.*-rc.*$/
+  stage: test-and-install
+  script:
+    - cd ./build && make -j$(nproc) performancetests &> performancetests.log
+    - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  dependencies: [build_test]
 
 
 tests_unit_debug:
-   stage: debug-test
-   script:
-     - cd ./build && make -j$(nproc) unittests &> unittests.log
-     - ../tests/summarise.sh unittests.log
-   only:
-     - master
-     - develop
-     - /^v.*-rc.*$/
-
+  stage: debug-test
+  script:
+    - cd ./build && make -j$(nproc) unittests &> unittests.log
+    - ../tests/summarise.sh unittests.log
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  dependencies: [build_test_debug]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,8 @@
-image: gcc:9.3
+default:
+  tags:
+    - docker
+  image: ${CI_REGISTRY}/${CI_PROJECT_PATH}/lpf-ubuntu-20.04-gcc
+
 
 stages:
   - build-and-secrets
@@ -114,14 +118,9 @@ stages:
 # Main testing on Ubuntu, all branches
 
 build_test:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: build-and-secrets
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
-    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install && make -j$(nproc) build_tests_all
+    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-lpf=${LPF_PATH} && make -j$(nproc) build_tests_all
     - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
   artifacts:
     paths:
@@ -135,23 +134,13 @@ build_test:
 
 
 build_debug2_tests:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: debug-build
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Debug ../ && make -j$(nproc) build_tests_all
 
 
 build_debugrelease_tests:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: build-and-secrets
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
   only:
@@ -165,8 +154,6 @@ build_debugrelease_tests:
 #
 # clang_linter:
 #   image: ubuntu:20.04
-#   tags:
-#     - docker
 #   stage: build-and-secrets
 #   before_script:
 #     - export DEBIAN_FRONTEND=noninteractive
@@ -179,44 +166,27 @@ build_debugrelease_tests:
 
 
 tests_unit:
-  tags:
-    - docker
   stage: test-and-install
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - cd ./build && make -j$(nproc) tests_unit &> unittests.log
     - ../tests/summarise.sh unittests.log
 
 
 tests_smoke:
-  tags:
-    - docker
   stage: test-and-install
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
     - ../tests/summarise.sh smoketests.log
 
 
 test_installation:
-  tags:
-    - docker
   stage: test-and-install
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - cd ./build && make -j$(nproc) install
 
 
 build_debug:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: debug-build
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - rm -rf build install && mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
   artifacts:
@@ -229,32 +199,20 @@ build_debug:
 
 
 test_smoke_debug:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: debug-test
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - cd ./build && make -j$(nproc) smoketests &> smoketests.log
     - ../tests/summarise.sh smoketests.log
 
 
 test_install_debug:
-  image: gcc:9.3
-  tags:
-    - docker
   stage: debug-test
-  before_script:
-    - apt update && apt -y install make cmake libnuma-dev coreutils
   script:
     - cd ./build && make -j$(nproc) install
 
 
 gitleaks:
   stage: build-and-secrets
-  tags:
-    - docker
   image:
     name: "zricethezav/gitleaks:v8.0.6"
     entrypoint: [""]
@@ -264,12 +222,7 @@ gitleaks:
 ## Additional tests specific to main branches only
 
 tests_performance:
-   image: gcc:9.3
-   tags:
-     - docker
    stage: test-and-install
-   before_script:
-     - apt update && apt -y install make cmake libnuma-dev coreutils
    script:
      - cd ./build && make -j$(nproc) performancetests &> performancetests.log
      - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
@@ -280,12 +233,7 @@ tests_performance:
 
 
 tests_unit_debug:
-   image: gcc:9.3
-   tags:
-     - docker
    stage: debug-test
-   before_script:
-     - apt update && apt -y install make cmake libnuma-dev coreutils
    script:
      - cd ./build && make -j$(nproc) unittests &> unittests.log
      - ../tests/summarise.sh unittests.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,9 +20,16 @@ workflow:
     - if: $CI_COMMIT_BRANCH =~ /^v.*-rc.*$/
       variables:
         IS_MAIN_PIPELINE: "yes"
-    - when: always  # trigger pipeline in any case
+  # rules to avoid duplicate pipelines on merge requests
+    # run if the pipeline comes from a merge request
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    # do not run when the commit has a branch name associated and this branch is associated to an MR
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
+      when: never
+    # run when the commit has a branch name associated
+    - if: $CI_COMMIT_BRANCH
 
-
+# factored out command to strip symbols from test binaries
 .strip_symbols: &strip_symbols
   - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,9 @@ workflow:
     - when: always  # trigger pipeline in any case
 
 
+.strip_symbols: &strip_symbols
+  - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+
 # Build / test / install on CentOS 8, only for main branches
 
 #build_centos_8:
@@ -34,7 +37,7 @@ workflow:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - rm -rf build install && mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install && make -j$(nproc) && make -j$(nproc) build_tests_all
-#    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+#    - *strip_symbols
 #  artifacts:
 #    paths:
 #      - build/
@@ -118,7 +121,7 @@ build_test:
   needs: []
   script:
     - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
-    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+    - *strip_symbols
   artifacts:
     paths:
       - build/
@@ -130,7 +133,7 @@ build_test:
     expire_in: 80 minutes
 
 
-build_tests_build_type_debug_sym_debug:
+build_tests_buildtype_debug_sym_debug:
   needs: []
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Debug ../ && make -j$(nproc) build_tests_all
@@ -164,11 +167,11 @@ test_installation:
     - cd ./build && make -j$(nproc) install
 
 
-build_test_build_type_debug:
+build_test_buildtype_debug:
   needs: []
   script:
     - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
-    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+    - *strip_symbols
   artifacts:
     paths:
       - build/
@@ -178,13 +181,13 @@ build_test_build_type_debug:
     expire_in: 43 minutes
 
 test_smoke_build_type_debug:
-  needs: [build_test_build_type_debug]
+  needs: [build_test_buildtype_debug]
   script:
     - cd ./build && make -j$(nproc) smoketests &> smoketests.log
     - ../tests/summarise.sh smoketests.log
 
 test_installation_build_type_debug:
-  needs: [build_test_build_type_debug]
+  needs: [build_test_buildtype_debug]
   script:
     - cd ./build && make -j$(nproc) install
 
@@ -208,12 +211,12 @@ tests_performance:
     - cd ./build && make -j$(nproc) performancetests &> performancetests.log
     - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
 
-tests_unit_build_type_debug:
+tests_unit_buildtype_debug:
   rules:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
-  needs: [build_test_build_type_debug]
+  needs: [build_test_buildtype_debug]
   script:
     - cd ./build && make -j$(nproc) unittests &> unittests.log
     - ../tests/summarise.sh unittests.log
@@ -228,9 +231,9 @@ build_test_lpf:
     - when: never
   needs: []
   script:
-# if we are on master develop or v/-rc branch (or attempting to merge onto them), build only LPF-related tests
+# build only LPF-related tests
     - mkdir -p install build && cd ./build && ../bootstrap.sh --with-lpf=${LPF_PATH} --no-nonblocking --no-reference --no-hyperdags --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
-    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+    - *strip_symbols
   artifacts:
     paths:
       - build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,16 +3,6 @@ default:
     - docker
   image: ${CI_REGISTRY}/${CI_PROJECT_PATH}/lpf-ubuntu-20.04-gcc
 
-
-# stages:
-#   - build-and-secrets
-#   - test-and-install
-#   - debug-build
-#   - debug-test
-#   - centos-build-and-debug
-#   - centos-test-and-install
-
-
 variables:
   IS_MAIN_PIPELINE: "no"
 
@@ -28,25 +18,24 @@ workflow:
     - if: $CI_COMMIT_BRANCH =~ /^v.*-rc.*$/
       variables:
         IS_MAIN_PIPELINE: "yes"
-# trigger pipeline in any case
-    - when: always
+    - when: always  # trigger pipeline in any case
+
 
 
 # Build / test / install on CentOS 8, only for main branches
 
 #build_centos_8:
 #  image: centos:8
-#  tags:
-#    - docker
-#  stage: centos-build-and-debug
+#  needs: []
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
 #  before_script:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - rm -rf build install && mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install && make -j$(nproc) && make -j$(nproc) build_tests_all
-#  only:
-#    - master
-#    - develop
-#    - /^v.*-rc.*$/
+#    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
 #  artifacts:
 #    paths:
 #      - build/
@@ -58,86 +47,75 @@ workflow:
 
 #build_debug_centos_8:
 #  image: centos:8
-#  tags:
-#    - docker
-#  stage: centos-build-and-debug
+#  needs: []
 #  before_script:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
-#  only:
-#    - master
-#    - develop
-#    - /^v.*-rc.*$/
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
 
 
 #test_centos_8_unit:
 #  image: centos:8
-#  tags:
-#    - docker
-#  stage: centos-test-and-install
+#  needs: [build_centos_8]
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
 #  before_script:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - cd ./build && make -j$(nproc) tests_unit &> unittests.log
 #    - ../tests/summarise.sh unittests.log
-#  only:
-#    - master
-#    - develop
-#    - /^v.*-rc.*$/
 
 
 #test_centos_8_smoke:
 #  image: centos:8
-#  tags:
-#    - docker
-#  stage: centos-test-and-install
+#  needs: [build_centos_8]
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
 #  before_script:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
 #    - ../tests/summarise.sh smoketests.log
-#  only:
-#    - master
-#    - develop
-#    - /^v.*-rc.*$/
 
 
 #test_centos_8_performance:
-#   image: centos:8
-#   tags:
-#     - docker
-#   stage: centos-test-and-install
-#   before_script:
-#     - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
-#   script:
-#     - cd ./build &&  make -j$(nproc) tests_performance &> performancetests.log
-#     - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
-#   only:
-#     - master
-#     - develop
-#     - /^v.*-rc.*$/
+#  image: centos:8
+#  needs: [build_centos_8]
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
+#  before_script:
+#    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
+#  script:
+#    - cd ./build &&  make -j$(nproc) tests_performance &> performancetests.log
+#    - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
 
 
 #test_centos_8_installation:
 #  image: centos:8
-#  tags:
-#    - docker
-#  stage: centos-test-and-install
+#  needs: [build_centos_8]
+#  rules:
+#    - if: $IS_MAIN_PIPELINE == "yes"
+#      when: on_success
+#    - when: never
 #  before_script:
 #    - yum -y update && yum -y groupinstall "Development Tools" && yum -y install make autoconf cmake numactl-devel
 #  script:
 #    - cd ./build && make -j$(nproc) install
-#  only:
-#    - master
-#    - develop
-#    - /^v.*-rc.*$/
 
 
 # Main testing on Ubuntu, all branches
 
 build_test:
-  # stage: build-and-secrets
   needs: []
   script:
 # if we are on master develop or v/-rc branch (or attempting to merge onto them), then also trigger LPF-related tests
@@ -155,63 +133,56 @@ build_test:
     expire_in: 80 minutes
 
 
-build_debug2_tests:
-  # stage: debug-build
+build_tests_build_type_debug_sym_debug:
   needs: []
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Debug ../ && make -j$(nproc) build_tests_all
 
 
-build_debugrelease_tests:
-  # stage: build-and-secrets
-  needs: []
-  script:
-    - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
+build_tests_sym_debug:
   rules:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
+  needs: []
+  script:
+    - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
 
 
 # linting is currently disabled since clang-format is not mature enough
 # and leads to weirdnesses and instabilities; we may reactivate it in future
 #
 # clang_linter:
-#   image: ubuntu:20.04
-#   stage: build-and-secrets
-#   before_script:
-#     - export DEBIAN_FRONTEND=noninteractive
-#     - apt update && apt install -y clang-format-11 git-core coreutils
-#   script:
-#     - tools/clang-format-linter.sh -i --lint-whole-grb
-#     - files="$(git status -s)"
-#     - if [[ ! -z "${files}" ]]; then echo "The following files do not abide by the official code style, you may use tools/clang-format-linter.sh to format them"; echo "${files[@]}"; else echo 'All files formatted correctly'; fi
-#     - if [[ ! -z "${files}" ]]; then exit 0; fi
+#  needs: [build_centos_8]
+#  before_script:
+#    - export DEBIAN_FRONTEND=noninteractive
+#    - apt update && apt install -y clang-format-11 git-core coreutils
+#  script:
+#    - tools/clang-format-linter.sh -i --lint-whole-grb
+#    - files="$(git status -s)"
+#    - if [[ ! -z "${files}" ]]; then echo "The following files do not abide by the official code style, you may use tools/clang-format-linter.sh to format them"; echo "${files[@]}"; else echo 'All files formatted correctly'; fi
+#    - if [[ ! -z "${files}" ]]; then exit 0; fi
 
 
 tests_unit:
-  # stage: test-and-install
   needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) tests_unit &> unittests.log
     - ../tests/summarise.sh unittests.log
 
 tests_smoke:
-  # stage: test-and-install
   needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
     - ../tests/summarise.sh smoketests.log
 
 test_installation:
-  # stage: test-and-install
   needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) install
 
 
-build_test_debug:
-  # stage: debug-build
+build_test_build_type_debug:
   needs: []
   script:
     - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
@@ -224,21 +195,18 @@ build_test_debug:
       - build/**/*.o.d
     expire_in: 43 minutes
 
-test_smoke_debug:
-  # stage: debug-test
-  needs: [build_test_debug]
+test_smoke_build_type_debug:
+  needs: [build_test_build_type_debug]
   script:
     - cd ./build && make -j$(nproc) smoketests &> smoketests.log
     - ../tests/summarise.sh smoketests.log
 
-test_install_debug:
-  # stage: debug-test
-  needs: [build_test_debug]
+test_installation_build_type_debug:
+  needs: [build_test_build_type_debug]
   script:
     - cd ./build && make -j$(nproc) install
 
 gitleaks:
-  # stage: build-and-secrets
   needs: []
   image:
     name: "zricethezav/gitleaks:v8.0.6"
@@ -249,23 +217,21 @@ gitleaks:
 ## Additional tests specific to main branches only
 
 tests_performance:
-  # stage: test-and-install
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
   needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) performancetests &> performancetests.log
     - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
+
+tests_unit_build_type_debug:
   rules:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
-
-tests_unit_debug:
-  # stage: debug-test
-  needs: [build_test_debug]
+  needs: [build_test_build_type_debug]
   script:
     - cd ./build && make -j$(nproc) unittests &> unittests.log
     - ../tests/summarise.sh unittests.log
-  rules:
-    - if: $IS_MAIN_PIPELINE == "yes"
-      when: on_success
-    - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,21 +149,6 @@ build_tests_sym_debug:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
 
 
-# linting is currently disabled since clang-format is not mature enough
-# and leads to weirdnesses and instabilities; we may reactivate it in future
-#
-# clang_linter:
-#  needs: [build_centos_8]
-#  before_script:
-#    - export DEBIAN_FRONTEND=noninteractive
-#    - apt update && apt install -y clang-format-11 git-core coreutils
-#  script:
-#    - tools/clang-format-linter.sh -i --lint-whole-grb
-#    - files="$(git status -s)"
-#    - if [[ ! -z "${files}" ]]; then echo "The following files do not abide by the official code style, you may use tools/clang-format-linter.sh to format them"; echo "${files[@]}"; else echo 'All files formatted correctly'; fi
-#    - if [[ ! -z "${files}" ]]; then exit 0; fi
-
-
 tests_unit:
   needs: [build_test]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+# default settings based on standard Docker image for reproducible build:
+# see https://github.com/Algebraic-Programming/ReproducibleBuilds
 default:
   tags:
     - docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,13 +4,13 @@ default:
   image: ${CI_REGISTRY}/${CI_PROJECT_PATH}/lpf-ubuntu-20.04-gcc
 
 
-stages:
-  - build-and-secrets
-  - test-and-install
-  - debug-build
-  - debug-test
-  - centos-build-and-debug
-  - centos-test-and-install
+# stages:
+#   - build-and-secrets
+#   - test-and-install
+#   - debug-build
+#   - debug-test
+#   - centos-build-and-debug
+#   - centos-test-and-install
 
 
 variables:
@@ -137,8 +137,8 @@ workflow:
 # Main testing on Ubuntu, all branches
 
 build_test:
-  stage: build-and-secrets
-  rules:
+  # stage: build-and-secrets
+  needs: []
   script:
 # if we are on master develop or v/-rc branch (or attempting to merge onto them), then also trigger LPF-related tests
     - if [ "${IS_MAIN_PIPELINE}" == "yes" ]; then LPF_SWITCH="--with-lpf=${LPF_PATH}"; fi
@@ -156,21 +156,21 @@ build_test:
 
 
 build_debug2_tests:
-  stage: debug-build
+  # stage: debug-build
+  needs: []
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Debug ../ && make -j$(nproc) build_tests_all
-  dependencies: []
 
 
 build_debugrelease_tests:
-  stage: build-and-secrets
+  # stage: build-and-secrets
+  needs: []
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
   rules:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
-  dependencies: []
 
 
 # linting is currently disabled since clang-format is not mature enough
@@ -190,29 +190,29 @@ build_debugrelease_tests:
 
 
 tests_unit:
-  stage: test-and-install
+  # stage: test-and-install
+  needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) tests_unit &> unittests.log
     - ../tests/summarise.sh unittests.log
-  dependencies: [build_test]
-
 
 tests_smoke:
-  stage: test-and-install
+  # stage: test-and-install
+  needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
     - ../tests/summarise.sh smoketests.log
-  dependencies: [build_test]
 
 test_installation:
-  stage: test-and-install
+  # stage: test-and-install
+  needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) install
-  dependencies: [build_test]
 
 
 build_test_debug:
-  stage: debug-build
+  # stage: debug-build
+  needs: []
   script:
     - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --debug-build && make -j$(nproc) && make -j$(nproc) build_tests_all
     - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
@@ -223,25 +223,23 @@ build_test_debug:
       - build/**/*.o
       - build/**/*.o.d
     expire_in: 43 minutes
-  dependencies: []
-
 
 test_smoke_debug:
-  stage: debug-test
+  # stage: debug-test
+  needs: [build_test_debug]
   script:
     - cd ./build && make -j$(nproc) smoketests &> smoketests.log
     - ../tests/summarise.sh smoketests.log
-  dependencies: [build_test_debug]
 
 test_install_debug:
-  stage: debug-test
+  # stage: debug-test
+  needs: [build_test_debug]
   script:
     - cd ./build && make -j$(nproc) install
-  dependencies: [build_test_debug]
-
 
 gitleaks:
-  stage: build-and-secrets
+  # stage: build-and-secrets
+  needs: []
   image:
     name: "zricethezav/gitleaks:v8.0.6"
     entrypoint: [""]
@@ -251,7 +249,8 @@ gitleaks:
 ## Additional tests specific to main branches only
 
 tests_performance:
-  stage: test-and-install
+  # stage: test-and-install
+  needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) performancetests &> performancetests.log
     - ../tests/summarise.sh performancetests.log tests/performance/output/benchmarks tests/performance/output/scaling
@@ -259,11 +258,10 @@ tests_performance:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
-  dependencies: [build_test]
-
 
 tests_unit_debug:
-  stage: debug-test
+  # stage: debug-test
+  needs: [build_test_debug]
   script:
     - cd ./build && make -j$(nproc) unittests &> unittests.log
     - ../tests/summarise.sh unittests.log
@@ -271,4 +269,3 @@ tests_unit_debug:
     - if: $IS_MAIN_PIPELINE == "yes"
       when: on_success
     - when: never
-  dependencies: [build_test_debug]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -284,5 +284,8 @@ build_test_gcc_versions:
         - CXX_COMPILER: g++
           CC_COMPILER: gcc
           VER: [9,10,11,12]
+        # - CXX_COMPILER: clang++
+        #   CC_COMPILER: clang
+        #   VER: [11,12,13,14]
   script:
     - mkdir -p install build && cd ./build && CXX=${CXX_COMPILER}-${VER} CC=${CC_COMPILER}-${VER} ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --with-lpf=${LPF_BASE_PATH}/build_mpich_${CC_COMPILER}_${VER}/install && make -j$(nproc) build_tests_all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,3 +269,20 @@ test_installation_lpf:
   needs: [build_test_lpf]
   script:
     - cd ./build && make -j$(nproc) install
+
+## Additional jobs to build againt multiple compilers (on main branches only)
+
+build_test_gcc_versions:
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  image: ${CI_REGISTRY}/${CI_PROJECT_PATH}/lpf-ubuntu-22.04-gcc-clang
+  needs: []
+  parallel:
+      matrix:
+        - CXX_COMPILER: g++
+          CC_COMPILER: gcc
+          VER: [9,10,11,12]
+  script:
+    - mkdir -p install build && cd ./build && CXX=${CXX_COMPILER}-${VER} CC=${CC_COMPILER}-${VER} ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} --with-lpf=${LPF_BASE_PATH}/build_mpich_${CC_COMPILER}_${VER}/install && make -j$(nproc) build_tests_all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ workflow:
     - when: always  # trigger pipeline in any case
 
 
-
 # Build / test / install on CentOS 8, only for main branches
 
 #build_centos_8:
@@ -118,9 +117,7 @@ workflow:
 build_test:
   needs: []
   script:
-# if we are on master develop or v/-rc branch (or attempting to merge onto them), then also trigger LPF-related tests
-    - if [ "${IS_MAIN_PIPELINE}" == "yes" ]; then LPF_SWITCH="--with-lpf=${LPF_PATH}"; fi
-    - mkdir -p install build && cd ./build && ../bootstrap.sh ${LPF_SWITCH} --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
+    - mkdir -p install build && cd ./build && ../bootstrap.sh --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
     - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
   artifacts:
     paths:
@@ -146,7 +143,7 @@ build_tests_sym_debug:
     - when: never
   needs: []
   script:
-    - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
+    - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG -DCMAKE_C_FLAGS=-D_DEBUG -DLPF_INSTALL_PATH=${LPF_PATH} -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
 
 
 tests_unit:
@@ -220,3 +217,55 @@ tests_unit_build_type_debug:
   script:
     - cd ./build && make -j$(nproc) unittests &> unittests.log
     - ../tests/summarise.sh unittests.log
+
+
+## Additional tests for LPF (on main branches only)
+
+build_test_lpf:
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: always
+    - when: never
+  needs: []
+  script:
+# if we are on master develop or v/-rc branch (or attempting to merge onto them), build only LPF-related tests
+    - mkdir -p install build && cd ./build && ../bootstrap.sh --with-lpf=${LPF_PATH} --no-nonblocking --no-reference --no-hyperdags --prefix=../install --with-datasets=${ALP_DATASETS} && make -j$(nproc) build_tests_all
+    - strip -s $(find tests/unit/ -type f -executable -print) $(find tests/smoke/ -type f -executable -print) $(find tests/performance/ -type f -executable -print)
+  artifacts:
+    paths:
+      - build/
+    exclude:
+      - build/**/*.o
+      - build/**/*.o.d
+      - build/**/CMakeFiles
+      - build/**/*.dir
+    expire_in: 80 minutes
+
+tests_unit_lpf:
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  needs: [build_test_lpf]
+  script:
+    - cd ./build && make -j$(nproc) tests_unit &> unittests.log
+    - ../tests/summarise.sh unittests.log
+
+tests_smoke_lpf:
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  needs: [build_test_lpf]
+  script:
+    - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
+    - ../tests/summarise.sh smoketests.log
+
+test_installation_lpf:
+  rules:
+    - if: $IS_MAIN_PIPELINE == "yes"
+      when: on_success
+    - when: never
+  needs: [build_test_lpf]
+  script:
+    - cd ./build && make -j$(nproc) install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,6 +73,7 @@ print_help() {
 the location where LPF is installed"
 	echo "  --with-banshee=<path/>              - path to the the tools to compile the banshee backend"
 	echo "  --with-snitch=<path/>               - path to the tools for Snitch support within the banshee backend"
+	echo "  --with-datasets=<path/>             - path to the main testing datasets (use tools/downloadDatasets.sh to download)"
 	echo "  --no-reference                      - disables the reference and reference_omp backends"
 	echo "  --no-hyperdags                      - disables the hyperdags backend"
 	echo "  --with-hyperdags-using=<backend>    - uses the given backend reference for HyperDAG generation"
@@ -108,6 +109,7 @@ SNITCH_PATH=
 debug_build=no
 generator=
 delete_files=no
+DATASETS_PATH=
 
 if [[ "$#" -lt 1 ]]; then
 	echo "No argument given, at least --prefix=<path/to/install/directory/> is mandatory"
@@ -150,6 +152,9 @@ or assume default paths (--with-lpf)"
 	--with-snitch=*)
 			SNITCH_PATH="${arg#--with-snitch=}"
 			banshee=yes
+			;;
+	--with-datasets=*)
+			DATASETS_PATH="${arg#--with-datasets=}"
 			;;
 	--no-reference)
 			reference=no
@@ -245,6 +250,9 @@ if [[ "${lpf}" == "yes" ]]; then
 	fi
 fi
 
+if [[ ! -z "${DATASETS_PATH}" ]]; then
+	DATASETS_PATH="$(realpath -e -q "${DATASETS_PATH/#\~/$HOME}")"
+fi
 
 if [[ "${banshee}" == "yes" ]]; then
 	ABSOLUTE_BANSHEE_PATH="$(realpath -e -q "${BANSHEE_PATH/#\~/$HOME}")"
@@ -309,9 +317,11 @@ the current directory before invocation or confirm the deletion of its content w
 		CMAKE_OPTS+=" -DCMAKE_BUILD_TYPE=Release"
 	fi
 
-	DATASETS_DIR="${CURRENT_DIR}/datasets"
-	if [[ -d "${DATASETS_DIR}" ]]; then
-		CMAKE_OPTS+=" -DDATASETS_DIR='${DATASETS_DIR}'"
+	DEFAULT_DATASETS_DIR="${CURRENT_DIR}/datasets"
+	if [[ ! -z "${DATASETS_PATH}" ]]; then
+		CMAKE_OPTS+=" -DDATASETS_DIR='${DATASETS_PATH}'"
+	elif [[ -d "${DEFAULT_DATASETS_DIR}" ]]; then
+		CMAKE_OPTS+=" -DDATASETS_DIR='${DEFAULT_DATASETS_DIR}'"
 	fi
 	# GNN_DATASET_PATH is not needed, because unittests.sh sets a default
 

--- a/docs/Build_and_test_infra.md
+++ b/docs/Build_and_test_infra.md
@@ -18,19 +18,20 @@ limitations under the License.
 
 - [Introduction to ALP/GraphBLAS Building and Testing Infrastructure:](#introduction-to-alpgraphblas-building-and-testing-infrastructure)
 - [The Building Infrastructure](#the-building-infrastructure)
-	- [Generation via the `bootstrap.sh` script](#generation-via-the-bootstrap-script)
-		- [Direct Generation via `cmake`](#direct-generation-via-cmake)
-		- [CMake Build Options, Types and Flags](#cmake-build-options-types-and-flags)
-	- [Naming conventions for targets](#naming-conventions-for-targets)
-	- [Adding a new test](#adding-a-new-test)
-	- [Adding a new backend](#adding-a-new-backend)
-		- [1. Add the related project options](#1-add-the-related-project-options)
-		- [2. Add the backend-specific variables](#2-add-the-backend-specific-variables)
-		- [3. Add the information to generate installation wrappers](#3-add-the-information-to-generate-installation-wrappers)
-		- [4. Add the headers target](#4-add-the-headers-target)
-		- [5. Add the binary target](#5-add-the-binary-target)
-		- [6. Add the backend name to the relevant tests](#6-add-the-backend-name-to-the-relevant-tests)
-- [The testing infrastructure](#the-testing-infrastructure)
+  - [Generation via the `bootstrap.sh` script](#generation-via-the-bootstrapsh-script)
+    - [Direct Generation via `cmake`](#direct-generation-via-cmake)
+    - [CMake Build Options, Types and Flags](#cmake-build-options-types-and-flags)
+  - [Naming conventions for targets](#naming-conventions-for-targets)
+  - [Adding a new test](#adding-a-new-test)
+  - [Adding a new backend](#adding-a-new-backend)
+    - [1. Add the related project options](#1-add-the-related-project-options)
+    - [2. Add the backend-specific variables](#2-add-the-backend-specific-variables)
+    - [3. Add the information to generate installation wrappers](#3-add-the-information-to-generate-installation-wrappers)
+    - [4. Add the headers target](#4-add-the-headers-target)
+    - [5. Add the binary target](#5-add-the-binary-target)
+    - [6. Add the backend name to the relevant tests](#6-add-the-backend-name-to-the-relevant-tests)
+- [Test Categories and modes](#test-categories-and-modes)
+- [Reproducible Builds](#reproducible-builds)
 
 # Introduction to ALP/GraphBLAS Building and Testing Infrastructure:
 
@@ -121,6 +122,8 @@ systems) and `Ninja` -- for more information, see
 runs of the script
 * `--delete-files` deletes all files in the current directory without asking for
 confirmation; it is iseful, for example, for scripted builds
+* `--with-datasets=<path/>` allows passing the path to the directory with the
+  datasets required to run some tests (otherwise skipped)
 * `--help` shows all available options and skips directory checks.
 
 For a dry run, just add the `--show` option to inspect the building command on
@@ -784,22 +787,7 @@ if( WITH_EXAMPLE_BACKEND )
     add_dependencies( examples sp_example )
 endif()
 ```
-# The testing infrastructure
-
-Tests are run via dedicated scripts in the project root, which invoke the
-specific test binaries.
-This solution deals with the complexity of testing ALP/GraphBLAS, whose
-different backends require different execution targets (shared-memory and a
-distributed system with an MPI or LPF launcher).
-
-These scripts are able to run tests compiled both via the previous Makefile
-infrastructure and via the new CMake one.
-
-In both cases, these scripts should be invoked via the corresponding
-`make` targets inside the build directory (e.g., `make unittests`): this
-invocation takes care of passing the scripts the relevant parameters (location
-of binaries, available backends, datasets location, output paths, ...) and, as
-usual, shows their output in the `stdout`.
+# Test Categories and modes
 
 Tests are grouped in *categories* according to what they test:
 
@@ -831,3 +819,22 @@ The various compilation flags and modes are defined and documented in the
 [CompileFlags.cmake file](../cmake/CompileFlags.cmake).
 During configuration this file generates a report with all compilation flags for
 the various target types and categories/modes.
+
+# Reproducible Builds
+To ease building and deploying ALP/GraphBLAS, dedicated Docker images can be
+built from the `Dockerfile`s in the *ALP/ReproducibleBuild* repository
+
+https://github.com/Algebraic-Programming/ReproducibleBuilds
+
+The images built from these files represent the standard build environment used
+by most ALP/GraphBLAS developers and contain all necessary dependencies to build
+*all* ALP/GraphBLAS backends and tests, including the necessary input datasets.
+You may refer to the
+[README](https://github.com/Algebraic-Programming/ReproducibleBuilds#readme) for
+more information about the content and how to build the images.
+
+The same images can be used for a Continuous Integration (CI) setup, as they
+provide all needed dependencies and tools.
+Indeed, the file [`.gitlab-ci.yml`](../.gitlab-ci.yml) describes the CI jobs
+that internally test ALP/GraphBLAS via [GitLab](https://about.gitlab.com/),
+which is available [open source](https://about.gitlab.com/install/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,9 @@ limitations under the License.
 * the [Development Guidelines](Development.md) to read about ALP/GraphBLAS'
 development philosophy and work with its codebase
 * the
-[guide to the current Building and Testing Infrastructure](Build_and_test_infra.md)
+[guide to the Building and Testing Infrastructure](Build_and_test_infra.md)
+* the
+[guide to run Tests](Run_tests.md)
 * the code documentation, generated via Doxygen through the building
 infrastructure (`make docs`) and available in the subdirectory `code`
 * the

--- a/docs/Run_tests.md
+++ b/docs/Run_tests.md
@@ -1,0 +1,44 @@
+<pre>
+  Copyright 2023 Huawei Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+
+The current testing infrastructure is composed of several scripts invoking the
+test binaries.
+Test binaries can be generated via the testing infrastructure,
+as from the [related guide](Build_and_test_infra.md#adding-a-new-test).
+Tests should be added to the scripts manually, invoking the appropriate launcher
+and passing the dedicated options.
+
+# Run ALP/GraphBLAS Tests
+
+Tests are run via dedicated scripts in the project root, which invoke the
+specific test binaries.
+This solution deals with the complexity of testing ALP/GraphBLAS, whose
+different backends require different execution targets (shared-memory and a
+distributed system with an MPI or LPF launcher).
+
+These scripts should be invoked via the corresponding `make` targets inside the
+build directory (e.g., `make unittests`): this invocation takes care of passing
+the scripts the relevant parameters (location of binaries, available backends,
+datasets location, output paths, ...) and, as usual, shows their output in the
+`stdout`.
+
+As from the
+[Reproducible Builds section](Build_and_test_infra.md#reproducible-builds),
+Docker images can be built to have a reproducible environment for building and
+testing.
+These images store all tools, dependencies and input datasets to build and run
+all backends and tests; you may refer to the
+[section](Build_and_test_infra.md#reproducible-builds) for more details.

--- a/tests/unit/parser.cpp
+++ b/tests/unit/parser.cpp
@@ -344,16 +344,17 @@ int main( int argc, char ** argv ) {
 		}
  #endif
 
-	} catch( std::runtime_error & e ) {
+	} catch( std::runtime_error &e ) {
 		std::cout << "Caught exception: " << e.what() << std::endl;
 		ret = 1;
 	}
 
 	// done
+	std::cerr << std::flush;
 	if( ret == 0 ) {
-		std::cout << "Test OK.\n" << std::endl;
+		std::cout << "Test OK\n" << std::endl;
 	} else {
-		std::cout << "Test FAILED.\n" << std::endl;
+		std::cout << "Test FAILED\n" << std::endl;
 	}
 	return ret;
 }

--- a/tests/unit/parser.cpp
+++ b/tests/unit/parser.cpp
@@ -199,10 +199,13 @@ bool readEdges(
 
 int main( int argc, char ** argv ) {
 	std::cout << "Functional test executable: " << argv[ 0 ] << "\n";
+
 	if( argc != 2 ) {
-		std::cout << "please, give path to cit-HepTh.txt" << std::endl;
-		std::exit( 1 );
+		std::cerr << "please, give path to cit-HepTh.txt" << std::endl;
+		std::cout << "Test FAILED" << std::endl;
+		return 255;
 	}
+
 	int ret = 0;
 
 	// a naive storage of the input matrix
@@ -243,8 +246,9 @@ int main( int argc, char ** argv ) {
 			ret = 2;
 		}
 
-		/* The below tests for automatic derivation of number of vertices, but this is not supported by the SNAP data files
-		* n = SIZE_MAX;
+		/* The below tests for automatic derivation of number of vertices, but this is
+		 * not supported by the SNAP data files
+		n = SIZE_MAX;
 		const bool rc2 = readEdges(
 			dataset_file, true, &n,
 			&nz, &I, &J, NULL
@@ -255,26 +259,30 @@ int main( int argc, char ** argv ) {
 		}
 		//check vertex count
 		if( n != 27770 ) {
-			std::cerr << "Direct parser could not derive correctly the number of vertices: returned " << n << " instead of 27770.\n";
+			std::cerr << "Direct parser could not derive correctly the number of "
+				<< "vertices: returned " << n << " instead of 27770.\n";
 			ret = 4;
 		}
 		//check nonzero count
 		if( nz != citHepTh.nz() ) {
 			std::cerr << "Direct parser nz count does not match util parser.\n";
 			ret = 5;
-		}*/
+		}
+		*/
 
 		// check synchronised iterator
 		auto synced_it = grb::internal::makeSynchronized( I, J, I + nz, J + nz );
 		for( size_t k = 0; ret == 0 && k < nz; ++k, ++synced_it ) {
 			if( I[ k ] != synced_it.i() ) {
-				std::cerr << "Synchronised file iterator has mismatching row indices at position "
-					<< k << ": read " << synced_it.i() << " instead of " << I[ k ] << "\n";
+				std::cerr << "Synchronised file iterator has mismatching row indices at "
+					<< "position " << k << ": read " << synced_it.i() << " instead of "
+					<< I[ k ] << "\n";
 				ret = 10;
 			}
 			if( J[ k ] != synced_it.j() ) {
-				std::cerr << "Synchronised file iterator has mismatching column indices at position "
-					<< k << ": read " << synced_it.j() << " instead of " << J[ k ] << "\n";
+				std::cerr << "Synchronised file iterator has mismatching column indices at "
+					<< "position " << k << ": read " << synced_it.j() << " instead of "
+					<< J[ k ] << "\n";
 				ret = 11;
 			}
 		}
@@ -285,39 +293,45 @@ int main( int argc, char ** argv ) {
 		}
 		if( nz != citHepTh.nz() ) {
 			std::cerr << "Util parsers imported into std::map< size_t, std::set< size_t > > "
-				<< "changes nonzero count ( " << nz << " versus " << citHepTh.nz() << " ).\n";
+				<< "changes nonzero count ( " << nz << " versus " << citHepTh.nz()
+				<< " ).\n";
 			ret = 20;
 		}
 
 		// use non-maximal util parser
 		grb::utils::MatrixFileReader< void > citHepTh2( dataset_file, false, true );
 
-		if( citHepTh.filename() != citHepTh2.filename() || citHepTh.m() != citHepTh2.m() ||
+		if(
+			citHepTh.filename() != citHepTh2.filename() ||
+			citHepTh.m() != citHepTh2.m() ||
 			citHepTh.n() != citHepTh2.n() || citHepTh.nz() != citHepTh2.nz() ||
 			citHepTh.isPattern() != citHepTh2.isPattern() ||
 			citHepTh.isSymmetric() != citHepTh2.isSymmetric() ||
 			citHepTh.usesDirectAddressing() != citHepTh2.usesDirectAddressing()
 		) {
-			std::cerr << "Inferred matrix properties do not match explicitly given matrix properties.\n";
+			std::cerr << "Inferred matrix properties do not match explicitly given "
+				<< "matrix properties.\n";
 			ret = 30;
 		}
 
 		// check contents
 		if( citHepTh.rowMap().size() != citHepTh2.rowMap().size() ) {
-			std::cerr << "Inferred matrix and explicit matrix row maps are not of equal size ("
-				<< citHepTh.rowMap().size() << " vs. " << citHepTh2.rowMap().size() << ").\n";
+			std::cerr << "Inferred matrix and explicit matrix row maps are not of equal "
+				<< "size (" << citHepTh.rowMap().size() << " vs. "
+				<< citHepTh2.rowMap().size() << ").\n";
 			ret = 33;
 		};
 		if( citHepTh.colMap().size() != citHepTh2.colMap().size() ) {
-			std::cerr << "Inferred matrix and explicit matrix col maps are not of equal size ("
-				<< citHepTh.colMap().size() << " vs. " << citHepTh2.colMap().size() << ").\n";
+			std::cerr << "Inferred matrix and explicit matrix col maps are not of equal "
+				<< "size (" << citHepTh.colMap().size() << " vs. "
+				<< citHepTh2.colMap().size() << ").\n";
 			ret = 36;
 		};
 
 		nz = 0;
 		for( const auto &nonzero : citHepTh2 ) {
-			(void)nonzero;
-			++nz;
+			(void) nonzero;
+			(void) ++nz;
 		}
 		if( nz != citHepTh.nz() ) {
 			std::cerr << "Inferred matrix does not contain all nonzeroes "
@@ -325,7 +339,8 @@ int main( int argc, char ** argv ) {
 			ret = 40;
 		}
 
- // the below test is incorrect since reordering of input changes indirect mappig
+ // the below test is incorrect since reordering of input changes indirect
+ // mapping
  #if 0
 		//check whether all nonzeroes are here
 		for( size_t i = 0; i < nz; ++i ) {
@@ -337,7 +352,8 @@ int main( int argc, char ** argv ) {
 			}
 			const auto col = row->second.find( J[ i ] );
 			if( col == row->second.end() ) {
-				std::cerr << "Nonzero at (" << I[i] << ", " << J[i] << ") not found in util-parsed matrix.\n";
+				std::cerr << "Nonzero at (" << I[i] << ", " << J[i] << ") not found in "
+					<< "util-parsed matrix.\n";
 				ret = 4;
 				break;
 			}
@@ -345,8 +361,8 @@ int main( int argc, char ** argv ) {
  #endif
 
 	} catch( std::runtime_error &e ) {
-		std::cout << "Caught exception: " << e.what() << std::endl;
-		ret = 1;
+		std::cerr << "Caught exception: " << e.what() << std::endl;
+		ret = 50;
 	}
 
 	// done

--- a/tests/unit/parser.cpp
+++ b/tests/unit/parser.cpp
@@ -197,15 +197,19 @@ bool readEdges(
  #include "graphblas/utils/parser.hpp"
 
 int main( int argc, char ** argv ) {
-	(void)argc;
 	std::cout << "Functional test executable: " << argv[ 0 ] << "\n";
+	if( argc != 2 ) {
+		std::cout << "please, give path to cit-HepTh.txt" << std::endl;
+		std::exit( 1 );
+	}
 	int ret = 0;
 
 	// a naive storage of the input matrix
 	std::map< size_t, std::set< size_t > > A;
 
 	// use utils parser
-	grb::utils::MatrixFileReader< void > citHepTh( "datasets/cit-HepTh.txt", false, true );
+	const char * const dataset_file = argv[ 1 ];
+	grb::utils::MatrixFileReader< void > citHepTh( dataset_file , false, true );
 
 	// fill A
 	for( const auto & nz : citHepTh ) {
@@ -226,7 +230,7 @@ int main( int argc, char ** argv ) {
 	// use direct parser
 	size_t nz, *I, *J, n;
 	n = 27770;
-	const bool rc = readEdges( "datasets/cit-HepTh.txt", true, &n, &nz, &I, &J, NULL );
+	const bool rc = readEdges( dataset_file, true, &n, &nz, &I, &J, NULL );
 	if( ! rc ) {
 		std::cerr << "Error in use of direct parser.\n";
 		ret = 1;
@@ -240,7 +244,7 @@ int main( int argc, char ** argv ) {
 	/* The below tests for automatic derivation of number of vertices, but this is not supported by the SNAP data files
 	 * n = SIZE_MAX;
 	const bool rc2 = readEdges(
-	    "datasets/cit-HepTh.txt", true, &n,
+	    dataset_file, true, &n,
 	    &nz, &I, &J, NULL
 	);
 	if( !rc2 ) {
@@ -284,7 +288,7 @@ int main( int argc, char ** argv ) {
 	}
 
 	// use non-maximal util parser
-	grb::utils::MatrixFileReader< void > citHepTh2( "datasets/cit-HepTh.txt", false, true );
+	grb::utils::MatrixFileReader< void > citHepTh2( dataset_file, false, true );
 
 	if( citHepTh.filename() != citHepTh2.filename() || citHepTh.m() != citHepTh2.m() ||
 		citHepTh.n() != citHepTh2.n() || citHepTh.nz() != citHepTh2.nz() ||

--- a/tests/unit/unittests.sh
+++ b/tests/unit/unittests.sh
@@ -49,7 +49,7 @@ for MODE in debug ndebug; do
 
 	echo ">>>      [x]           [ ]       Tests the built-in parser on the west0497 MatrixMarket file"
 	if [ -f ${INPUT_DIR}/west0497.mtx ]; then
-		${TEST_BIN_DIR}/parserTest_${MODE} 2> ${TEST_OUT_DIR}/parserTest_${MODE}.err 1> ${TEST_OUT_DIR}/parserTest_${MODE}.out
+		${TEST_BIN_DIR}/parserTest_${MODE} ${INPUT_DIR}/west0497.mtx 2> ${TEST_OUT_DIR}/parserTest_${MODE}.err 1> ${TEST_OUT_DIR}/parserTest_${MODE}.out
 		head -1 ${TEST_OUT_DIR}/parserTest_${MODE}.out
 		grep 'Test OK' ${TEST_OUT_DIR}/parserTest_${MODE}.out || echo "Test FAILED"
 	else
@@ -60,7 +60,7 @@ for MODE in debug ndebug; do
 	echo ">>>      [x]           [ ]       Tests the built-in parser (in graphblas/utils/parser.hpp)"
 	echo "                                 versus the parser in tests/parser.cpp on cit-HepTh.txt."
 	if [ -f ${INPUT_DIR}/cit-HepTh.txt ]; then
-		${TEST_BIN_DIR}/compareParserTest_${MODE} &> ${TEST_OUT_DIR}/compareParserTest_${MODE}
+		${TEST_BIN_DIR}/compareParserTest_${MODE} ${INPUT_DIR}/cit-HepTh.txt &> ${TEST_OUT_DIR}/compareParserTest_${MODE}
 		head -1 ${TEST_OUT_DIR}/compareParserTest_${MODE}
 		tail -2 ${TEST_OUT_DIR}/compareParserTest_${MODE}
 	else

--- a/tests/unit/utilParserTest.cpp
+++ b/tests/unit/utilParserTest.cpp
@@ -20,11 +20,14 @@
 
 #include "graphblas/utils/parser.hpp"
 
+
 int main( int argc, char ** argv ) {
 	std::cout << "Functional test executable: " << argv[ 0 ] << "\n";
+
 	if( argc != 2 ) {
-		std::cout << "please, give path to west0497.mtx" << std::endl;
-		std::exit( 1 );
+		std::cerr << "please, give path to west0497.mtx" << std::endl;
+		std::cout << "Test FAILED" << std::endl;
+		return 255;
 	}
 
 	int ret = 0;
@@ -43,21 +46,18 @@ int main( int argc, char ** argv ) {
 			ret = 3;
 		}
 		if( west.isPattern() == true ) {
-			std::cerr << "west0497 is not a pattern matrix, yet it is detected to "
-						"be one."
-					<< std::endl;
+			std::cerr << "west0497 is not a pattern matrix, yet it is detected to be "
+				<< "a pattern matrix." << std::endl;
 			ret = 4;
 		}
 		if( west.isSymmetric() == true ) {
-			std::cerr << "west0497 is not a symmetric matrix, yet it is detected "
-						"to be one."
-					<< std::endl;
+			std::cerr << "west0497 is not a symmetric matrix, yet it is detected to be "
+				<< "to be symmetric." << std::endl;
 			ret = 5;
 		}
 		if( west.usesDirectAddressing() == false ) {
-			std::cerr << "west0497 should be read with direct addressing, not an "
-						"indirect one."
-					<< std::endl;
+			std::cerr << "west0497 should be read with direct addressing, not using "
+				<< "indirect addressing." << std::endl;
 			ret = 6;
 		}
 		size_t count = 0;
@@ -66,35 +66,40 @@ int main( int argc, char ** argv ) {
 			++count;
 		}
 		if( count != west.nz() ) {
-			std::cerr << "Iterator does not contain " << west.nz() << " nonzeroes. It instead iterated over " << count << " nonzeroes." << std::endl;
+			std::cerr << "Iterator does not contain " << west.nz() << " nonzeroes. "
+				<< "It instead iterated over " << count << " nonzeroes." << std::endl;
 			ret = 7;
 		}
-		auto base_it = west.begin( grb::SEQUENTIAL, []( double & val ) {
+		auto base_it = west.begin( grb::SEQUENTIAL, []( double &val ) {
 			val = 1;
 		} );
 		count = 0;
 		size_t count_converted = 0;
 		for( ; base_it != west.end(); ++base_it ) {
 			count_converted += static_cast< size_t >( ( *base_it ).second );
-			++count;
+			(void) ++count;
 		}
 		if( count != west.nz() ) {
-			std::cerr << "Iterator (non-auto) does not contain " << west.nz() << " nonzeroes. It instead iterated over " << count << " nonzeroes." << std::endl;
+			std::cerr << "Iterator (non-auto) does not contain " << west.nz()
+				<< " nonzeroes. It instead iterated over " << count
+				<< " nonzeroes." << std::endl;
 			ret = 8;
 		}
 		if( count != count_converted ) {
 			std::cerr << "Reader converter failed." << std::endl;
 			ret = 9;
 		}
-	} catch( std::runtime_error & e ) {
+	} catch( std::runtime_error &e ) {
 		std::cout << "Caught exception: " << e.what() << std::endl;
-		ret = 1;
+		ret = 10;
 	}
 
+	std::cerr << std::flush;
 	if( ret == 0 ) {
-		std::cout << "Test OK.\n" << std::endl;
+		std::cout << "Test OK\n" << std::endl;
 	} else {
-		std::cout << "Test FAILED.\n" << std::endl;
+		std::cout << "Test FAILED\n" << std::endl;
 	}
 	return ret;
 }
+

--- a/tests/unit/utilParserTest.cpp
+++ b/tests/unit/utilParserTest.cpp
@@ -20,9 +20,12 @@
 #include "graphblas/utils/parser.hpp"
 
 int main( int argc, char ** argv ) {
-	(void)argc;
 	std::cout << "Functional test executable: " << argv[ 0 ] << "\n";
-	grb::utils::MatrixFileReader< double, unsigned short int > west( "datasets/west0497.mtx" );
+	if( argc != 2 ) {
+		std::cout << "please, give path to west0497.mtx" << std::endl;
+		std::exit( 1 );
+	}
+	grb::utils::MatrixFileReader< double, unsigned short int > west( argv[ 1 ] );
 	int ret = 0;
 	if( west.m() != 497 ) {
 		std::cerr << "west0497 has 497 rows, not " << west.m() << std::endl;


### PR DESCRIPTION
This PR restructures the internal CI adding several features:
- testing inside a custom Docker container, with pre-compiled LPF and datasets (i.e., easily reproducible builds)
- hence, enabling tests with LPF and datasets
- tests against multiple GCC versions
- task-based description of CI jobs, with full parallelism and minimal dependencies (explicitly written)

@anyzelman This PR should have **high priority**, since a couple of incoming PRs depend on it. At the same time, existing PRs do **not** depend on it.