### PR TITLE
629 missing type definitions for multiple backends

### DIFF
--- a/include/graphblas/bsp1d/matrix.hpp
+++ b/include/graphblas/bsp1d/matrix.hpp
@@ -318,6 +318,16 @@ namespace grb {
 
 		public:
 
+			/** @see Matrix::value_type */
+			typedef D value_type;
+
+			/** The iterator type over matrices of this type. */
+			typedef typename internal::Compressed_Storage<
+				D, RowIndexType, NonzeroIndexType
+			>::template ConstIterator<
+				internal::Distribution< BSP1D >
+			> const_iterator;
+
 			/**
 			 * Matrix constructor.
 			 *

--- a/include/graphblas/bsp1d/matrix.hpp
+++ b/include/graphblas/bsp1d/matrix.hpp
@@ -322,11 +322,7 @@ namespace grb {
 			typedef D value_type;
 
 			/** The iterator type over matrices of this type. */
-			typedef typename internal::Compressed_Storage<
-				D, RowIndexType, NonzeroIndexType
-			>::template ConstIterator<
-				internal::Distribution< BSP1D >
-			> const_iterator;
+			typedef typename LocalMatrix::const_iterator const_iterator;
 
 			/**
 			 * Matrix constructor.

--- a/include/graphblas/hyperdags/matrix.hpp
+++ b/include/graphblas/hyperdags/matrix.hpp
@@ -108,6 +108,16 @@ namespace grb {
 
 		public:
 
+			/** @see Matrix::value_type */
+			typedef T value_type;
+
+			/** The iterator type over matrices of this type. */
+			typedef typename internal::Compressed_Storage<
+				T, grb::config::RowIndexType, grb::config::NonzeroIndexType
+			>::template ConstIterator< internal::Distribution<
+				_GRB_WITH_HYPERDAGS_USING> 
+			> const_iterator;
+
 			/** \internal Base constructor, no capacity */
 			Matrix( const size_t rows, const size_t columns ) :
 				matrix( rows, columns )

--- a/include/graphblas/hyperdags/matrix.hpp
+++ b/include/graphblas/hyperdags/matrix.hpp
@@ -112,11 +112,7 @@ namespace grb {
 			typedef T value_type;
 
 			/** The iterator type over matrices of this type. */
-			typedef typename internal::Compressed_Storage<
-				T, grb::config::RowIndexType, grb::config::NonzeroIndexType
-			>::template ConstIterator< internal::Distribution<
-				_GRB_WITH_HYPERDAGS_USING> 
-			> const_iterator;
+			typedef typename MyMatrixType::const_iterator const_iterator;
 
 			/** \internal Base constructor, no capacity */
 			Matrix( const size_t rows, const size_t columns ) :

--- a/include/graphblas/nonblocking/matrix.hpp
+++ b/include/graphblas/nonblocking/matrix.hpp
@@ -478,6 +478,13 @@ namespace grb {
 			/** @see Matrix::value_type */
 			typedef D value_type;
 
+			/** The iterator type over matrices of this type. */
+			typedef typename internal::Compressed_Storage<
+				D, RowIndexType, NonzeroIndexType
+			>::template ConstIterator<
+				internal::Distribution< reference >
+			> const_iterator;
+
 			Matrix(
 				const size_t rows, const size_t columns, const size_t nz
 			) : ref( rows, columns, nz )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -279,6 +279,10 @@ add_grb_executables( properties static_asserts/properties.cpp
 	BACKENDS reference reference_omp bsp1d hybrid hyperdags nonblocking
 )
 
+add_grb_executables( matrix_type static_asserts/matrix.cpp
+	BACKENDS reference reference_omp bsp1d hybrid hyperdags nonblocking
+)
+
 # targets to list and build the test for this category
 get_property( unit_tests_list GLOBAL PROPERTY tests_category_unit )
 add_custom_target( "list_tests_category_unit"

--- a/tests/unit/static_asserts/matrix.cpp
+++ b/tests/unit/static_asserts/matrix.cpp
@@ -1,0 +1,32 @@
+
+/*
+ *   Copyright 2021 Huawei Technologies Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <graphblas.hpp>
+
+
+int main() {
+	typedef grb::Matrix< double > MatrixType;
+	static_assert( std::is_same<
+			std::pair<
+				std::pair< const size_t, const size_t >,
+				const MatrixType::value_type
+			>,
+			std::iterator_traits< typename MatrixType::const_iterator >::value_type
+		>::value, "Matrix iterator has an unexpected value type" );
+	return 0;
+}
+

--- a/tests/unit/static_asserts/matrix.cpp
+++ b/tests/unit/static_asserts/matrix.cpp
@@ -20,13 +20,26 @@
 
 int main() {
 	typedef grb::Matrix< double > MatrixType;
+	typedef grb::Matrix< void > VMatrixType;
+	static_assert( std::is_same< double, typename MatrixType::value_type >::value,
+		"Matrix has unexpected value type" );
+	static_assert( std::is_same< void, typename VMatrixType::value_type >::value,
+		"Void matrix has unexpected value type" );
 	static_assert( std::is_same<
 			std::pair<
 				std::pair< const size_t, const size_t >,
-				const MatrixType::value_type
+				const typename MatrixType::value_type
 			>,
-			std::iterator_traits< typename MatrixType::const_iterator >::value_type
+			typename std::iterator_traits<
+					typename MatrixType::const_iterator
+				>::value_type
 		>::value, "Matrix iterator has an unexpected value type" );
+	static_assert( std::is_same<
+			std::pair< const size_t, const size_t >,
+			typename std::iterator_traits<
+					typename VMatrixType::const_iterator
+				>::value_type
+		>::value, "Void matrix iterator has an unexpected value type" );
 	return 0;
 }
 


### PR DESCRIPTION
### Main idea:
Declare the Matrix internal types __value\_type__ and __const\_iterator__ for all backends, as it's already done for the _base_ and _reference_ ones. This would allow the users to consider _base_ as the general interface for a non-specialized usage of grb.

Defined in the [reference backend](https://github.com/Algebraic-Programming/ALP/blob/master/include/graphblas/reference/matrix.hpp#L1864-1872):
```c++
/** @see Matrix::value_type */
typedef D value_type;

/** The iterator type over matrices of this type. */
typedef typename internal::Compressed_Storage<
	D, RowIndexType, NonzeroIndexType
>::template ConstIterator<
	internal::Distribution< reference >
> const_iterator;
```