### PR TITLE
Fix GitLab CI + small improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -358,6 +358,7 @@ coverage_matrix:
   artifacts:
     paths:
       - COVERAGE_${CI_JOB_ID}.json
+    expire_in: 4 weeks
 
 cobertura_coverage_report:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,7 +279,8 @@ build_test_lpf:
 tests_unit_lpf:
   rules:
     - if: $LPF_TESTS_ENABLED == "yes"
-      when: on_success
+  tags:
+    - high-core # LPF requires a lot of cores
   needs: [build_test_lpf]
   script:
     - cd ./build && make -j$(nproc) tests_unit &> unittests.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,7 +277,7 @@ build_test_lpf:
 .tests_unit_lpf:
   needs: [build_test_lpf]
   script:
-    - cd ./build && make -j$(nproc) tests_unit | tee unittests.log
+    - cd ./build && make -j$(nproc) tests_unit &> unittests.log
     - ../tests/summarise.sh unittests.log
 
 # this job triggers in internal CI, where LPF tests run better on runners

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,7 +180,6 @@ build_tests_buildtype_debug_sym_debug:
 build_tests_sym_debug:
   rules:
     - if: $EXTRA_TESTS_ENABLED == "yes"
-      when: on_success
   script:
     - mkdir -p install build && cd build && cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=-D_DEBUG
       -DCMAKE_C_FLAGS=-D_DEBUG -DLPF_INSTALL_PATH=${LPF_PATH} -DCMAKE_BUILD_TYPE=Release ../ && make -j$(nproc) build_tests_all
@@ -240,7 +239,6 @@ gitleaks:
 tests_performance:
   rules:
     - if: $EXTRA_TESTS_ENABLED == "yes"
-      when: on_success
   needs: [build_test]
   script:
     - cd ./build && make -j$(nproc) performancetests &> performancetests.log
@@ -249,7 +247,6 @@ tests_performance:
 tests_unit_buildtype_debug:
   rules:
     - if: $EXTRA_TESTS_ENABLED == "yes"
-      when: on_success
   needs: [build_test_buildtype_debug]
   script:
     - cd ./build && make -j$(nproc) unittests &> unittests.log
@@ -289,7 +286,6 @@ tests_unit_lpf:
 tests_smoke_lpf:
   rules:
     - if: $LPF_TESTS_ENABLED == "yes"
-      when: on_success
   needs: [build_test_lpf]
   script:
     - cd ./build && make -j$(nproc) tests_smoke &> smoketests.log
@@ -298,7 +294,6 @@ tests_smoke_lpf:
 test_installation_lpf:
   rules:
     - if: $LPF_TESTS_ENABLED == "yes"
-      when: on_success
   needs: [build_test_lpf]
   script:
     - cd ./build && make -j$(nproc) install
@@ -308,7 +303,6 @@ test_installation_lpf:
 build_test_gcc_versions:
   rules:
     - if: $MULTIPLE_COMPILERS_ENABLED == "yes"
-      when: on_success
   image: ${CI_REGISTRY}/${CI_PROJECT_PATH}/lpf-ubuntu-22.04-gcc-clang
   parallel:
       matrix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -347,6 +347,7 @@ coverage_matrix:
       -DWITH_REFERENCE_BACKEND=${backends_array[1]}
       -DWITH_OMP_BACKEND=${backends_array[2]}
       -DWITH_NONBLOCKING_BACKEND=${backends_array[3]} ..
+    - make -j$(nproc)
     - make -j$(nproc) unittests
 # for each job (i.e., each backend), generate a separate JSON to me merged later
 # (gcovr merges only JSON files)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,15 +273,29 @@ build_test_lpf:
       - build/**/*.dir
     expire_in: 2 hours
 
-tests_unit_lpf:
-  rules:
-    - if: $LPF_TESTS_ENABLED == "yes"
-  tags:
-    - high-core # LPF requires a lot of cores
+# common sections for  LPF unit tests
+.tests_unit_lpf:
   needs: [build_test_lpf]
   script:
-    - cd ./build && make -j$(nproc) tests_unit &> unittests.log
+    - cd ./build && make -j$(nproc) tests_unit | tee unittests.log
     - ../tests/summarise.sh unittests.log
+
+# this job triggers in internal CI, where LPF tests run better on runners
+# with a given tag $LPF_PREFERRED_RUNNERS_TAG
+tests_unit_lpf_preferred:
+  rules:
+    - if: $LPF_TESTS_ENABLED == "yes" && $LPF_PREFERRED_RUNNERS == "yes"
+  tags:
+    - docker
+    - $LPF_PREFERRED_RUNNERS_TAG
+  extends: .tests_unit_lpf
+
+# if runners with a specific tag are not present, run this job
+# attention: it may timeout
+tests_unit_lpf_generic:
+  rules:
+    - if: $LPF_TESTS_ENABLED == "yes" && $LPF_PREFERRED_RUNNERS != "yes"
+  extends: .tests_unit_lpf
 
 tests_smoke_lpf:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,7 +340,9 @@ coverage_matrix:
     - echo "-- NONBLOCKING=${backends_array[3]}"
 
     - rm -rf build install && mkdir -p install build && cd build
-    - cmake -DCMAKE_INSTALL_PREFIX='../install' -DCMAKE_BUILD_TYPE=Coverage
+    - cmake -DCMAKE_INSTALL_PREFIX='../install' 
+      -DCMAKE_BUILD_TYPE=Coverage
+      -DDATASETS_DIR=${ALP_DATASETS}
       -DWITH_HYPERDAGS_BACKEND=${backends_array[0]}
       -DWITH_REFERENCE_BACKEND=${backends_array[1]}
       -DWITH_OMP_BACKEND=${backends_array[2]}

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -71,7 +71,7 @@ set_valid_string( COMMON_OPTS_Debug "${COMMON_COMPILE_OPTIONS}"
 	"${COMMON_OPTS};-fno-omit-frame-pointer"
 )
 set_valid_string( COMMON_OPTS_Coverage "${COMMON_COMPILE_OPTIONS}"
-	"${COMMON_OPTS};-fprofile-arcs;-ftest-coverage"
+	"${COMMON_OPTS};-fprofile-arcs;-ftest-coverage;-fprofile-update=atomic"
 )
 
 add_library( common_flags INTERFACE )

--- a/docs/Build_and_test_infra.md
+++ b/docs/Build_and_test_infra.md
@@ -835,6 +835,7 @@ During configuration this file generates a report with all compilation flags for
 the various target types and categories/modes.
 
 # Reproducible Builds
+
 To ease building and deploying ALP/GraphBLAS, dedicated Docker images can be
 built from the `Dockerfile`s in the *ALP/ReproducibleBuild* repository
 
@@ -852,6 +853,9 @@ provide all needed dependencies and tools.
 Indeed, the file [`.gitlab-ci.yml`](../.gitlab-ci.yml) describes the CI jobs
 that internally test ALP/GraphBLAS via [GitLab](https://about.gitlab.com/),
 which is available [open source](https://about.gitlab.com/install/).
+
+The here described image and CI pipeline are confirmed to work with x86 runners
+with 24 virtual CPU cores and 32GB RAM.
 
 # The coverage infrastructure
 

--- a/src/transition/CMakeLists.txt
+++ b/src/transition/CMakeLists.txt
@@ -20,43 +20,46 @@
 
 assert_defined_variables( WITH_REFERENCE_BACKEND WITH_OMP_BACKEND )
 
-add_library( sparseblas_static STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/sparseblas.cpp
-)
+if( WITH_REFERENCE_BACKEND )
+	add_library( sparseblas_static STATIC
+		${CMAKE_CURRENT_SOURCE_DIR}/sparseblas.cpp
+	)
 
-set_target_properties( sparseblas_static PROPERTIES
-	OUTPUT_NAME "sparseblas"
-	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shmem"
-)
+	set_target_properties( sparseblas_static PROPERTIES
+		OUTPUT_NAME "sparseblas"
+		ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shmem"
+	)
 
-target_link_libraries( sparseblas_static PUBLIC backend_reference transition )
+	target_link_libraries( sparseblas_static PUBLIC backend_reference transition )
 
-target_link_libraries( sparseblas_static PRIVATE backend_flags )
+	target_link_libraries( sparseblas_static PRIVATE backend_flags )
 
-add_dependencies( libs sparseblas_static )
+	add_dependencies( libs sparseblas_static )
 
-install( TARGETS sparseblas_static
-	EXPORT GraphBLASTargets
-	ARCHIVE DESTINATION "${SHMEM_BACKEND_INSTALL_DIR}"
-)
+	install( TARGETS sparseblas_static
+		EXPORT GraphBLASTargets
+		ARCHIVE DESTINATION "${SHMEM_BACKEND_INSTALL_DIR}"
+	)
+endif( WITH_REFERENCE_BACKEND )
 
-add_library( sparseblas_omp_static STATIC
-	${CMAKE_CURRENT_SOURCE_DIR}/sparseblas.cpp
-)
+if( WITH_OMP_BACKEND )
+	add_library( sparseblas_omp_static STATIC
+		${CMAKE_CURRENT_SOURCE_DIR}/sparseblas.cpp
+	)
 
-set_target_properties( sparseblas_omp_static PROPERTIES
-	OUTPUT_NAME "sparseblas_omp"
-	ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shmem"
-)
+	set_target_properties( sparseblas_omp_static PROPERTIES
+		OUTPUT_NAME "sparseblas_omp"
+		ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/shmem"
+	)
 
-target_link_libraries( sparseblas_omp_static PUBLIC backend_reference_omp transition )
+	target_link_libraries( sparseblas_omp_static PUBLIC backend_reference_omp transition )
 
-target_link_libraries( sparseblas_omp_static PRIVATE backend_flags )
+	target_link_libraries( sparseblas_omp_static PRIVATE backend_flags )
 
-add_dependencies( libs sparseblas_omp_static )
+	add_dependencies( libs sparseblas_omp_static )
 
-install( TARGETS sparseblas_omp_static
-	EXPORT GraphBLASTargets
-	ARCHIVE DESTINATION "${SHMEM_BACKEND_INSTALL_DIR}"
-)
-
+	install( TARGETS sparseblas_omp_static
+		EXPORT GraphBLASTargets
+		ARCHIVE DESTINATION "${SHMEM_BACKEND_INSTALL_DIR}"
+	)
+endif()


### PR DESCRIPTION
Minors changes:
- `test-unit_lpf` now requires a `high_core` tagged runner in order to avoid timeout. Fix in [this commit](https://github.com/Algebraic-Programming/ALP/commit/942ad9ffdddf00cfbd57a4ac1e23ec39c41bf375).
- Some tests were skipped during the coverage, it was due to the missing CMake `DATASET_DIR` variable during the build. Fix in [this commit](https://github.com/Algebraic-Programming/ALP/commit/914ddba02b64d0d721d6726fbda5be6487946db8).
- Compilation of sparseblas.cpp was failing when the `reference` backend only was enabled. Fix in [this commit](https://github.com/Algebraic-Programming/ALP/commit/ba7b9261fb6a9f80a9f9b29a13c7f68018694d11).
- Fix sporadic bug of Coverage with OpenMP. See [this gcovr issue](https://github.com/gcovr/gcovr/issues/583#issuecomment-1340762818). Fix in [this commit](https://github.com/Algebraic-Programming/ALP/commit/b82f70d9f26af5f7c16d7220a572383d9a739a82)