### PR TITLE
656 grb::set vector empty-masked is broken

### DIFF
--- a/include/graphblas/nonblocking/io.hpp
+++ b/include/graphblas/nonblocking/io.hpp
@@ -388,9 +388,9 @@ namespace grb {
 			"vector"
 		);
 
-		// catch empty mask
+		// If the mask is empty: clear the vector
 		if( size( m ) == 0 ) {
-			return set< descr >( x, val, phase );
+			return clear( x );
 		}
 
 		// dynamic sanity checks

--- a/include/graphblas/reference/io.hpp
+++ b/include/graphblas/reference/io.hpp
@@ -469,9 +469,9 @@ namespace grb {
 			"vector"
 		);
 
-		// catch empty mask
+		// If the mask is empty: clear the vector
 		if( size( m ) == 0 ) {
-			return set< descr >( x, val, phase );
+			return clear( x );
 		}
 
 		// dynamic sanity checks


### PR DESCRIPTION
Closes #247 

Would require #246 to be merged before, as this particular case could be tested into the new unit test.