### PR TITLE
260 bicgstab smoke tests sometimes does not report useful time 1

### DIFF
--- a/tests/smoke/bicgstab.cpp
+++ b/tests/smoke/bicgstab.cpp
@@ -32,14 +32,14 @@ using namespace grb;
 using namespace algorithms;
 
 
-constexpr double TOL = 0.0001;
+constexpr const double tol = 0.0001;
 
 /** Default maximum number of solver iterations */
-constexpr size_t MAX_ITERS = 10000;
+constexpr const size_t max_iters = 10000;
 
-constexpr double C1 = 0.001;
+constexpr const double c1 = 0.001;
 
-constexpr double C2 = 0.001;
+constexpr const double c2 = 0.001;
 
 struct input {
 	char filename[ 1024 ];
@@ -147,19 +147,19 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		timer.reset();
 		rc = bicgstab(
 			x, L, b,
-			data_in.solver_iterations, TOL,
+			data_in.solver_iterations, tol,
 			out.iterations, out.residual,
 			r, buf1, buf2, buf3, buf4, buf5,
 			ring, minus, divide
 		);
 		double single_time = timer.time();
 		if( !(rc == SUCCESS || rc == FAILED) ) {
-			std::cerr << "Failure: call to bicgstab not succeed ("
+			std::cerr << "Failure: call to BiCGstab not succeed ("
 				<< toString( rc ) << ")." << std::endl;
 			out.error_code = 20;
 		}
 		if( rc == FAILED ) {
-			std::cout << "Warning: call to conjugate_gradient did not converge\n";
+			std::cout << "Warning: call to BiCGstab did not converge\n";
 		}
 		if( rc == SUCCESS ) {
 			rc = collectives<>::reduce( single_time, 0, operators::max< double >() );
@@ -172,9 +172,9 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		if( rc == SUCCESS || rc == FAILED ) {
 			if( s == 0 ) {
 				if( rc == FAILED ) {
-					std::cout << "Info: cold bicgstab did not converge within ";
+					std::cout << "Info: cold BiCGstab did not converge within ";
 				} else {
-					std::cout << "Info: cold bicgstab completed within ";
+					std::cout << "Info: cold BiCGstab completed within ";
 				}
 				std::cout << out.iterations << " iterations. Last computed residual is "
 					<< out.residual << ". Time taken was " << single_time << " ms. "
@@ -193,7 +193,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			if( rc == SUCCESS ) {
 				rc = bicgstab(
 					x, L, b,
-					data_in.solver_iterations, TOL,
+					data_in.solver_iterations, tol,
 					out.iterations, out.residual,
 					r, buf1, buf2, buf3, buf4, buf5
 				);
@@ -205,7 +205,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		if( grb::spmd<>::pid() == 0 ) {
 			std::cout << "Time taken for " << out.rep << " BiCGstab "
 				<< "calls (hot start): " << out.times.useful << ". "
-				<< "Error code is " << out.error_code << std::endl;
+				<< "Error code is " << grb::toString( rc ) << std::endl;
 			std::cout << "\tnumber of BiCGstab iterations: " << out.iterations << "\n";
 			std::cout << "\tmilliseconds per iteration: "
 				<< ( out.times.useful / static_cast< double >( out.iterations ) )
@@ -255,7 +255,7 @@ int main( int argc, char ** argv ) {
 			<< grb::config::BENCHMARKING::outer()
 			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(solver iterations) is optional, the default is "
-			<< MAX_ITERS
+			<< max_iters
 			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(verification <truth-file>) is optional." << std::endl;
 		return 0;
@@ -299,7 +299,7 @@ int main( int argc, char ** argv ) {
 		}
 	}
 
-	in.solver_iterations = MAX_ITERS;
+	in.solver_iterations = max_iters;
 	if( argc >= 6 ) {
 		in.solver_iterations = strtoumax( argv[ 5 ], &end, 10 );
 		if( argv[ 5 ] == end ) {
@@ -388,7 +388,7 @@ int main( int argc, char ** argv ) {
 		if( verification ) {
 			out.error_code = vector_verification(
 				out.pinnedVector, truth_filename,
-				C1, C2
+				c1, c2
 			);
 			if( out.error_code == 0 ) {
 				std::cout << "Output vector verificaton was successful!\n";

--- a/tests/smoke/bicgstab.cpp
+++ b/tests/smoke/bicgstab.cpp
@@ -28,20 +28,24 @@
 #include <graphblas.hpp>
 #include <utils/output_verification.hpp>
 
-#define TOL 0.0001
-#define MAX_ITERS 10000
-
-#define C1 0.001
-#define C2 0.001
-
-
 using namespace grb;
 using namespace algorithms;
+
+
+constexpr double TOL = 0.0001;
+
+/** Default maximum number of solver iterations */
+constexpr size_t MAX_ITERS = 10000;
+
+constexpr double C1 = 0.001;
+
+constexpr double C2 = 0.001;
 
 struct input {
 	char filename[ 1024 ];
 	bool direct;
 	size_t rep;
+	size_t solver_iterations;
 };
 
 struct output {
@@ -143,7 +147,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		timer.reset();
 		rc = bicgstab(
 			x, L, b,
-			MAX_ITERS, TOL,
+			data_in.solver_iterations, TOL,
 			out.iterations, out.residual,
 			r, buf1, buf2, buf3, buf4, buf5,
 			ring, minus, divide
@@ -189,7 +193,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			if( rc == SUCCESS ) {
 				rc = bicgstab(
 					x, L, b,
-					MAX_ITERS, TOL,
+					data_in.solver_iterations, TOL,
 					out.iterations, out.residual,
 					r, buf1, buf2, buf3, buf4, buf5
 				);
@@ -199,8 +203,8 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		out.times.useful = time_taken / static_cast< double >( out.rep );
 		// print timing at root process
 		if( grb::spmd<>::pid() == 0 ) {
-			std::cout << "Time taken for a " << out.rep << " "
-				<< "Conjugate Gradients calls (hot start): " << out.times.useful << ". "
+			std::cout << "Time taken for " << out.rep << " BiCGstab "
+				<< "calls (hot start): " << out.times.useful << ". "
 				<< "Error code is " << out.error_code << std::endl;
 			std::cout << "\tnumber of BiCGstab iterations: " << out.iterations << "\n";
 			std::cout << "\tmilliseconds per iteration: "
@@ -236,18 +240,23 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 
 int main( int argc, char ** argv ) {
 	// sanity check
-	if( argc < 3 || argc > 7 ) {
+	if( argc < 3 || argc > 8 ) {
 		std::cout << "Usage: " << argv[ 0 ]
 			<< " <dataset> <direct/indirect> "
-			<< "(inner iterations) (outer iterations) (verification <truth-file>)\n";
+			<< "(inner iterations) (outer iterations) (solver iterations) "
+			<< "(verification <truth-file>)\n";
 		std::cout << "<dataset> and <direct/indirect> are mandatory arguments.\n";
 		std::cout << "(inner iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::inner() << ". "
-			<< "If set to zero, the program will select a number of iterations "
-			<< "approximately required to take at least one second to complete.\n";
+			<< "If this integer is set to zero, the program will select a number of "
+			<< "inner iterations that results in at least one second of computation "
+			<< "time.\n";
 		std::cout << "(outer iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::outer()
-			<< ". This value must be strictly larger than 0.\n";
+			<< ". This integer must be strictly larger than 0.\n";
+		std::cout << "(solver iterations) is optional, the default is "
+			<< MAX_ITERS
+			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(verification <truth-file>) is optional." << std::endl;
 		return 0;
 	}
@@ -257,7 +266,7 @@ int main( int argc, char ** argv ) {
 	struct input in;
 
 	// get file name
-	(void)strncpy( in.filename, argv[ 1 ], 1023 );
+	(void) strncpy( in.filename, argv[ 1 ], 1023 );
 	in.filename[ 1023 ] = '\0';
 
 	// get direct or indirect addressing
@@ -273,9 +282,9 @@ int main( int argc, char ** argv ) {
 	if( argc >= 4 ) {
 		in.rep = strtoumax( argv[ 3 ], &end, 10 );
 		if( argv[ 3 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 2 ] << " "
+			std::cerr << "Could not parse argument " << argv[ 3 ] << " "
 				<< "for number of inner experiment repititions." << std::endl;
-			return 2;
+			return 20;
 		}
 	}
 
@@ -284,35 +293,47 @@ int main( int argc, char ** argv ) {
 	if( argc >= 5 ) {
 		outer = strtoumax( argv[ 4 ], &end, 10 );
 		if( argv[ 4 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 3 ] << " "
+			std::cerr << "Could not parse argument " << argv[ 4 ] << " "
 				<< "for number of outer experiment repititions." << std::endl;
-			return 4;
+			return 40;
+		}
+	}
+
+	in.solver_iterations = MAX_ITERS;
+	if( argc >= 6 ) {
+		in.solver_iterations = strtoumax( argv[ 5 ], &end, 10 );
+		if( argv[ 5 ] == end ) {
+			std::cerr << "Could not parse argument " << argv[ 5 ] << " "
+				<< "for the maximum number of solver iterations." << std::endl;
+			return 50;
 		}
 	}
 
 	// check for verification of the output
 	bool verification = false;
 	char truth_filename[ 1024 ];
-	if( argc >= 6 ) {
-		if( strncmp( argv[ 5 ], "verification", 12 ) == 0 ) {
+	if( argc >= 7 ) {
+		if( strncmp( argv[ 6 ], "verification", 12 ) == 0 ) {
 			verification = true;
-			if( argc >= 7 ) {
-				(void)strncpy( truth_filename, argv[ 6 ], 1023 );
+			if( argc >= 8 ) {
+				(void) strncpy( truth_filename, argv[ 7 ], 1023 );
 				truth_filename[ 1023 ] = '\0';
 			} else {
 				std::cerr << "The verification file was not provided as an argument."
 					<< std::endl;
-				return 5;
+				return 60;
 			}
 		} else {
-			std::cerr << "Could not parse argument \"" << argv[ 5 ] << "\", "
+			std::cerr << "Could not parse argument \"" << argv[ 6 ] << "\", "
 				<< "the optional \"verification\" argument was expected." << std::endl;
-			return 5;
+			return 70;
 		}
 	}
 
 	std::cout << "Executable called with parameters " << in.filename << ", "
-		<< "inner repititions = " << in.rep << ", and outer reptitions = " << outer
+		<< "inner repititions = " << in.rep << ", "
+		<< "outer reptitions = " << outer << ", and "
+		<< "solver iterations = " << in.solver_iterations << "."
 		<< std::endl;
 
 	// the output struct
@@ -331,7 +352,7 @@ int main( int argc, char ** argv ) {
 		if( rc != SUCCESS ) {
 			std::cerr << "launcher.exec returns with non-SUCCESS error code "
 				<< (int)rc << std::endl;
-			return 6;
+			return 80;
 		}
 	}
 
@@ -343,7 +364,7 @@ int main( int argc, char ** argv ) {
 	if( rc != SUCCESS ) {
 		std::cerr << "benchmarker.exec returns with non-SUCCESS error code "
 			<< grb::toString( rc ) << std::endl;
-		return 8;
+		return 90;
 	} else if( out.error_code == 0 ) {
 		std::cout << "Benchmark completed successfully and took " << out.iterations
 			<< " iterations to converge with residual " << out.residual << ".\n";

--- a/tests/smoke/conjugate_gradient.cpp
+++ b/tests/smoke/conjugate_gradient.cpp
@@ -86,12 +86,12 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 
 	// create local parser
 	grb::utils::MatrixFileReader< ScalarType,
-			std::conditional<
-				(sizeof( grb::config::RowIndexType ) > sizeof( grb::config::ColIndexType )),
-				grb::config::RowIndexType,
-				grb::config::ColIndexType
-			>::type
-		> parser( data_in.filename, data_in.direct );
+		std::conditional<
+			(sizeof( grb::config::RowIndexType ) > sizeof( grb::config::ColIndexType )),
+			grb::config::RowIndexType,
+			grb::config::ColIndexType
+		>::type
+	> parser( data_in.filename, data_in.direct );
 	assert( parser.m() == parser.n() );
 	const size_t n = parser.n();
 	out.times.io = timer.time();
@@ -152,10 +152,13 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			r, u, temp
 		);
 		double single_time = timer.time();
-		if( rc != SUCCESS ) {
+		if( !(rc == SUCCESS || rc == FAILED) ) {
 			std::cerr << "Failure: call to conjugate_gradient did not succeed ("
 				<< toString( rc ) << ")." << std::endl;
 			out.error_code = 20;
+		}
+		if( rc == FAILED ) {
+			std::cout << "Warning: call to conjugate_gradient did not converge\n";
 		}
 		if( rc == SUCCESS ) {
 			rc = collectives<>::reduce( single_time, 0, operators::max< double >() );
@@ -165,10 +168,14 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		}
 		out.times.useful = single_time;
 		out.rep = static_cast< size_t >( 1000.0 / single_time ) + 1;
-		if( rc == SUCCESS ) {
+		if( rc == SUCCESS || rc == FAILED ) {
 			if( s == 0 ) {
-				std::cout << "Info: cold conjugate_gradient completed within "
-					<< out.iterations << " iterations. Last computed residual is "
+				if( rc == FAILED ) {
+					std::cout << "Info: cold conjugate_gradient did not converge within ";
+				} else {
+					std::cout << "Info: cold conjugate_gradient completed within ";
+				}
+				std::cout << out.iterations << " iterations. Last computed residual is "
 					<< out.residual << ". Time taken was " << single_time << " ms. "
 					<< "Deduced inner repetitions parameter of " << out.rep << " "
 					<< "to take 1 second or more per inner benchmark.\n";

--- a/tests/smoke/conjugate_gradient.cpp
+++ b/tests/smoke/conjugate_gradient.cpp
@@ -43,13 +43,13 @@ using BaseScalarType = double;
  using ScalarType = BaseScalarType;
 #endif
 
-constexpr BaseScalarType TOL = 0.000001;
+constexpr const BaseScalarType tol = 0.000001;
 
 /** The default number of maximum iterations. */
-constexpr size_t MAX_ITERS = 10000;
+constexpr const size_t max_iters = 10000;
 
-constexpr double C1 = 0.0001;
-constexpr double C2 = 0.0001;
+constexpr const double c1 = 0.0001;
+constexpr const double c2 = 0.0001;
 
 struct input {
 	char filename[ 1024 ];
@@ -150,7 +150,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		timer.reset();
 		rc = conjugate_gradient(
 			x, L, b,
-			data_in.solver_iterations, TOL,
+			data_in.solver_iterations, tol,
 			out.iterations, out.residual,
 			r, u, temp
 		);
@@ -195,7 +195,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			if( rc == SUCCESS ) {
 				rc = conjugate_gradient(
 					x, L, b,
-					data_in.solver_iterations, TOL,
+					data_in.solver_iterations, tol,
 					out.iterations, out.residual,
 					r, u, temp
 				);
@@ -207,7 +207,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		if( grb::spmd<>::pid() == 0 ) {
 			std::cout << "Time taken for " << out.rep << " "
 				<< "Conjugate Gradients calls (hot start): " << out.times.useful << ". "
-				<< "Error code is " << out.error_code << std::endl;
+				<< "Error code is " << grb::toString( rc ) << std::endl;
 			std::cout << "\tnumber of CG iterations: " << out.iterations << "\n";
 			std::cout << "\tmilliseconds per iteration: "
 				<< ( out.times.useful / static_cast< double >( out.iterations ) )
@@ -257,7 +257,7 @@ int main( int argc, char ** argv ) {
 			<< grb::config::BENCHMARKING::outer()
 			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(solver iterations) is optional, the default is "
-			<< MAX_ITERS
+			<< max_iters
 			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(verification <truth-file>) is optional." << std::endl;
 		return 0;
@@ -301,7 +301,7 @@ int main( int argc, char ** argv ) {
 		}
 	}
 
-	in.solver_iterations = MAX_ITERS;
+	in.solver_iterations = max_iters;
 	if( argc >= 6 ) {
 		in.solver_iterations = strtoumax( argv[ 5 ], &end, 10 );
 		if( argv[ 5 ] == end ) {
@@ -390,7 +390,7 @@ int main( int argc, char ** argv ) {
 		if( verification ) {
 			out.error_code = vector_verification(
 				out.pinnedVector, truth_filename,
-				C1, C2
+				c1, c2
 			);
 			if( out.error_code == 0 ) {
 				std::cout << "Output vector verificaton was successful!\n";

--- a/tests/smoke/conjugate_gradient.cpp
+++ b/tests/smoke/conjugate_gradient.cpp
@@ -32,6 +32,10 @@
 #include <graphblas.hpp>
 #include <utils/output_verification.hpp>
 
+using namespace grb;
+using namespace algorithms;
+
+
 using BaseScalarType = double;
 #ifdef _CG_COMPLEX
  using ScalarType = std::complex< BaseScalarType >;
@@ -39,20 +43,19 @@ using BaseScalarType = double;
  using ScalarType = BaseScalarType;
 #endif
 
+constexpr BaseScalarType TOL = 0.000001;
 
-constexpr BaseScalarType TOL=0.000001;
-constexpr size_t MAX_ITERS=10000;
+/** The default number of maximum iterations. */
+constexpr size_t MAX_ITERS = 10000;
 
-constexpr double C1=0.0001;
-constexpr double C2=0.0001;
-
-using namespace grb;
-using namespace algorithms;
+constexpr double C1 = 0.0001;
+constexpr double C2 = 0.0001;
 
 struct input {
 	char filename[ 1024 ];
 	bool direct;
 	size_t rep;
+	size_t solver_iterations;
 };
 
 struct output {
@@ -147,7 +150,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		timer.reset();
 		rc = conjugate_gradient(
 			x, L, b,
-			MAX_ITERS, TOL,
+			data_in.solver_iterations, TOL,
 			out.iterations, out.residual,
 			r, u, temp
 		);
@@ -192,7 +195,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			if( rc == SUCCESS ) {
 				rc = conjugate_gradient(
 					x, L, b,
-					MAX_ITERS, TOL,
+					data_in.solver_iterations, TOL,
 					out.iterations, out.residual,
 					r, u, temp
 				);
@@ -202,7 +205,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		out.times.useful = time_taken / static_cast< double >( out.rep );
 		// print timing at root process
 		if( grb::spmd<>::pid() == 0 ) {
-			std::cout << "Time taken for a " << out.rep << " "
+			std::cout << "Time taken for " << out.rep << " "
 				<< "Conjugate Gradients calls (hot start): " << out.times.useful << ". "
 				<< "Error code is " << out.error_code << std::endl;
 			std::cout << "\tnumber of CG iterations: " << out.iterations << "\n";
@@ -239,18 +242,23 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 
 int main( int argc, char ** argv ) {
 	// sanity check
-	if( argc < 3 || argc > 7 ) {
+	if( argc < 3 || argc > 8 ) {
 		std::cout << "Usage: " << argv[ 0 ]
 			<< " <dataset> <direct/indirect> "
-			<< "(inner iterations) (outer iterations) (verification <truth-file>)\n";
+			<< "(inner iterations) (outer iterations) (solver iterations) "
+			<< "(verification <truth-file>)\n";
 		std::cout << "<dataset> and <direct/indirect> are mandatory arguments.\n";
 		std::cout << "(inner iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::inner() << ". "
-			<< "If set to zero, the program will select a number of iterations "
-			<< "approximately required to take at least one second to complete.\n";
+			<< "If this integer is set to zero, the program will select a number of "
+			<< "inner iterations that results in at least one second of computation "
+			<< "time.\n";
 		std::cout << "(outer iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::outer()
-			<< ". This value must be strictly larger than 0.\n";
+			<< ". This integer must be strictly larger than 0.\n";
+		std::cout << "(solver iterations) is optional, the default is "
+			<< MAX_ITERS
+			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(verification <truth-file>) is optional." << std::endl;
 		return 0;
 	}
@@ -260,7 +268,7 @@ int main( int argc, char ** argv ) {
 	struct input in;
 
 	// get file name
-	(void)strncpy( in.filename, argv[ 1 ], 1023 );
+	(void) strncpy( in.filename, argv[ 1 ], 1023 );
 	in.filename[ 1023 ] = '\0';
 
 	// get direct or indirect addressing
@@ -276,9 +284,9 @@ int main( int argc, char ** argv ) {
 	if( argc >= 4 ) {
 		in.rep = strtoumax( argv[ 3 ], &end, 10 );
 		if( argv[ 3 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 2 ] << " "
+			std::cerr << "Could not parse argument " << argv[ 3 ] << " "
 				<< "for number of inner experiment repititions." << std::endl;
-			return 2;
+			return 20;
 		}
 	}
 
@@ -287,35 +295,47 @@ int main( int argc, char ** argv ) {
 	if( argc >= 5 ) {
 		outer = strtoumax( argv[ 4 ], &end, 10 );
 		if( argv[ 4 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 3 ] << " "
+			std::cerr << "Could not parse argument " << argv[ 4 ] << " "
 				<< "for number of outer experiment repititions." << std::endl;
-			return 4;
+			return 40;
+		}
+	}
+
+	in.solver_iterations = MAX_ITERS;
+	if( argc >= 6 ) {
+		in.solver_iterations = strtoumax( argv[ 5 ], &end, 10 );
+		if( argv[ 5 ] == end ) {
+			std::cerr << "Could not parse argument " << argv[ 5 ] << " "
+				<< "for the maximum number of solver iterations." << std::endl;
+			return 50;
 		}
 	}
 
 	// check for verification of the output
 	bool verification = false;
 	char truth_filename[ 1024 ];
-	if( argc >= 6 ) {
-		if( strncmp( argv[ 5 ], "verification", 12 ) == 0 ) {
+	if( argc >= 7 ) {
+		if( strncmp( argv[ 6 ], "verification", 12 ) == 0 ) {
 			verification = true;
-			if( argc >= 7 ) {
-				(void)strncpy( truth_filename, argv[ 6 ], 1023 );
+			if( argc >= 8 ) {
+				(void) strncpy( truth_filename, argv[ 7 ], 1023 );
 				truth_filename[ 1023 ] = '\0';
 			} else {
 				std::cerr << "The verification file was not provided as an argument."
 					<< std::endl;
-				return 5;
+				return 60;
 			}
 		} else {
-			std::cerr << "Could not parse argument \"" << argv[ 5 ] << "\", "
+			std::cerr << "Could not parse argument \"" << argv[ 6 ] << "\", "
 				<< "the optional \"verification\" argument was expected." << std::endl;
-			return 5;
+			return 70;
 		}
 	}
 
 	std::cout << "Executable called with parameters " << in.filename << ", "
-		<< "inner repititions = " << in.rep << ", and outer reptitions = " << outer
+		<< "inner repititions = " << in.rep << ", "
+		<< "outer reptitions = " << outer << ", and "
+		<< "solver iterations = " << in.solver_iterations << "."
 		<< std::endl;
 
 	// the output struct
@@ -334,7 +354,7 @@ int main( int argc, char ** argv ) {
 		if( rc != SUCCESS ) {
 			std::cerr << "launcher.exec returns with non-SUCCESS error code "
 				<< (int)rc << std::endl;
-			return 6;
+			return 80;
 		}
 	}
 
@@ -346,7 +366,7 @@ int main( int argc, char ** argv ) {
 	if( rc != SUCCESS ) {
 		std::cerr << "benchmarker.exec returns with non-SUCCESS error code "
 			<< grb::toString( rc ) << std::endl;
-		return 8;
+		return 90;
 	} else if( out.error_code == 0 ) {
 		std::cout << "Benchmark completed successfully and took " << out.iterations
 			<< " iterations to converge with residual " << out.residual << ".\n";

--- a/tests/smoke/simple_pagerank.cpp
+++ b/tests/smoke/simple_pagerank.cpp
@@ -31,12 +31,13 @@
 using namespace grb;
 using namespace algorithms;
 
+
 /** Default maximum number of iterations. */
-constexpr size_t max_iters = 1000;
+constexpr const size_t max_iters = 1000;
 
-constexpr double alpha = 0.85;
+constexpr const double alpha = 0.85;
 
-constexpr double tol = 1e-7;
+constexpr const double tol = 1e-7;
 
 struct input {
 	char filename[ 1024 ];
@@ -188,7 +189,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		if( grb::spmd<>::pid() == 0 ) {
 			std::cout << "Time taken for " << out.rep
 				<< " PageRank calls (hot start): " << out.times.useful << ". "
-				<< "Error code is " << out.error_code << std::endl;
+				<< "Error code is " << grb::toString( rc ) << std::endl;
 			std::cout << "\tnumber of PR iterations: " << out.iterations << "\n";
 			std::cout << "\tmilliseconds per iteration: "
 				<< (out.times.useful / static_cast< double >( out.iterations )) << "\n";

--- a/tests/smoke/simple_pagerank.cpp
+++ b/tests/smoke/simple_pagerank.cpp
@@ -28,14 +28,21 @@
 #include <graphblas.hpp>
 #include <utils/output_verification.hpp>
 
-
 using namespace grb;
 using namespace algorithms;
+
+/** Default maximum number of iterations. */
+constexpr size_t max_iters = 1000;
+
+constexpr double alpha = 0.85;
+
+constexpr double tol = 1e-7;
 
 struct input {
 	char filename[ 1024 ];
 	bool direct;
 	size_t rep;
+	size_t solver_iterations;
 };
 
 struct output {
@@ -70,9 +77,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 	// create local parser
 	grb::utils::MatrixFileReader< void,
 		std::conditional<
-			(
-				sizeof( grb::config::RowIndexType ) > sizeof( grb::config::ColIndexType )
-			),
+			(sizeof( grb::config::RowIndexType ) > sizeof( grb::config::ColIndexType )),
 			grb::config::RowIndexType,
 			grb::config::ColIndexType
 		>::type
@@ -128,7 +133,7 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		rc = simple_pagerank< descriptors::no_operation >(
 			pr, L,
 			buf1, buf2, buf3,
-			0.85, 1e-7, 1000,
+			alpha, tol, data_in.solver_iterations,
 			&( out.iterations ), &( out.residual )
 		);
 		double single_time = timer.time();
@@ -172,24 +177,23 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 				rc = simple_pagerank< descriptors::no_operation >(
 					pr, L,
 					buf1, buf2, buf3,
-					0.85, 1e-7, 1000,
+					alpha, tol, data_in.solver_iterations,
 					&( out.iterations ), &( out.residual )
 				);
 			}
 		}
 		time_taken = timer.time();
-		if( rc == SUCCESS ) {
-			out.times.useful = time_taken / static_cast< double >( out.rep );
-		}
-		sleep( 1 );
-#ifndef NDEBUG
+		out.times.useful = time_taken / static_cast< double >( out.rep );
 		// print timing at root process
 		if( grb::spmd<>::pid() == 0 ) {
-			std::cout << "Time taken for a " << out.rep
+			std::cout << "Time taken for " << out.rep
 				<< " PageRank calls (hot start): " << out.times.useful << ". "
 				<< "Error code is " << out.error_code << std::endl;
+			std::cout << "\tnumber of PR iterations: " << out.iterations << "\n";
+			std::cout << "\tmilliseconds per iteration: "
+				<< (out.times.useful / static_cast< double >( out.iterations )) << "\n";
 		}
-#endif
+		sleep( 1 );
 	}
 
 	// start postamble
@@ -218,18 +222,23 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 
 int main( int argc, char ** argv ) {
 	// sanity check
-	if( argc < 3 || argc > 7 ) {
+	if( argc < 3 || argc > 8 ) {
 		std::cout << "Usage: " << argv[ 0 ] << " "
 			<< "<dataset> <direct/indirect> "
-			<< "(inner iterations) (outer iterations) (verification <truth-file>)\n";
+			<< "(inner iterations) (outer iterations) (solver iterations) "
+			<< "(verification <truth-file>)\n";
 		std::cout << "<dataset> and <direct/indirect> are mandatory arguments.\n";
 		std::cout << "(inner iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::inner() << ". "
-			<< "If set to zero, the program will select a number of iterations "
-			<< "approximately required to take at least one second to complete.\n";
+			<< "If this integer is set to zero, the program will select a number of "
+			<< "inner iterations that results in at least one second of computation "
+			<< "time.\n";
 		std::cout << "(outer iterations) is optional, the default is "
 			<< grb::config::BENCHMARKING::outer()
-			<< ". This value must be strictly larger than 0.\n";
+			<< ". This integer must be strictly larger than 0.\n";
+		std::cout << "(solver iterations) is optional, the default is "
+			<< max_iters
+			<< ". This integer must be strictly larger than 0.\n";
 		std::cout << "(verification <truth-file>) is optional. "
 			<< "The <truth-file> must point to a pre-computed solution that the "
 			<< "computed solution will be verified against." << std::endl;
@@ -241,7 +250,7 @@ int main( int argc, char ** argv ) {
 	struct input in;
 
 	// get file name
-	(void)strncpy( in.filename, argv[ 1 ], 1023 );
+	(void) strncpy( in.filename, argv[ 1 ], 1023 );
 	in.filename[ 1023 ] = '\0';
 
 	// get direct or indirect addressing
@@ -257,9 +266,9 @@ int main( int argc, char ** argv ) {
 	if( argc >= 4 ) {
 		in.rep = strtoumax( argv[ 3 ], &end, 10 );
 		if( argv[ 3 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 2 ]
+			std::cerr << "Could not parse argument " << argv[ 3 ]
 				<< " for number of inner experiment repititions." << std::endl;
-			return 2;
+			return 20;
 		}
 	}
 
@@ -268,36 +277,47 @@ int main( int argc, char ** argv ) {
 	if( argc >= 5 ) {
 		outer = strtoumax( argv[ 4 ], &end, 10 );
 		if( argv[ 4 ] == end ) {
-			std::cerr << "Could not parse argument " << argv[ 3 ]
+			std::cerr << "Could not parse argument " << argv[ 4 ]
 				<< " for number of outer experiment repititions." << std::endl;
-			return 4;
+			return 40;
+		}
+	}
+
+	in.solver_iterations = max_iters;
+	if( argc >= 6 ) {
+		in.solver_iterations = strtoumax( argv[ 5 ], &end, 10 );
+		if( argv[ 5 ] == end ) {
+			std::cerr << "Could not parse argument " << argv[ 5 ] << " "
+				<< "for the maximum number of solver iterations." << std::endl;
+			return 50;
 		}
 	}
 
 	// check for verification of the output
 	bool verification = false;
 	char truth_filename[ 1024 ];
-	if( argc >= 6 ) {
-		if( strncmp( argv[ 5 ], "verification", 12 ) == 0 ) {
+	if( argc >= 7 ) {
+		if( strncmp( argv[ 6 ], "verification", 12 ) == 0 ) {
 			verification = true;
-			if( argc >= 7 ) {
-				(void)strncpy( truth_filename, argv[ 6 ], 1023 );
+			if( argc >= 8 ) {
+				(void) strncpy( truth_filename, argv[ 7 ], 1023 );
 				truth_filename[ 1023 ] = '\0';
 			} else {
 				std::cerr << "The verification file was not provided as an argument."
 					<< std::endl;
-				return 5;
+				return 60;
 			}
 		} else {
-			std::cerr << "Could not parse argument \"" << argv[ 5 ] << "\", "
+			std::cerr << "Could not parse argument \"" << argv[ 6 ] << "\", "
 				<< "the optional \"verification\" argument was expected." << std::endl;
-			return 5;
+			return 70;
 		}
 	}
 
 	std::cout << "Executable called with parameters " << in.filename << ", "
-		<< "inner repititions = " << in.rep << ", "
-		<< "and outer reptitions = " << outer << std::endl;
+		<< "inner repetitions = " << in.rep << ", "
+		<< "outer repetitions = " << outer << ", and "
+		<< "solver iterations = " << in.solver_iterations << "." << std::endl;
 
 	// the output struct
 	struct output out;
@@ -315,7 +335,7 @@ int main( int argc, char ** argv ) {
 		if( rc != SUCCESS ) {
 			std::cerr << "launcher.exec returns with non-SUCCESS error code "
 				<< (int)rc << std::endl;
-			return 6;
+			return 80;
 		}
 	}
 

--- a/tests/smoke/simple_pagerank.cpp
+++ b/tests/smoke/simple_pagerank.cpp
@@ -132,10 +132,13 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 			&( out.iterations ), &( out.residual )
 		);
 		double single_time = timer.time();
-		if( rc != SUCCESS ) {
+		if( !(rc == SUCCESS || rc == FAILED) ) {
 			std::cerr << "Failure: call to simple_pagerank did not succeed "
 				<< "(" << toString( rc ) << ")." << std::endl;
 			out.error_code = 20;
+		}
+		if( rc == FAILED ) {
+			std::cout << "Warning: call to simple_pagerank did not converge\n";
 		}
 		if( rc == SUCCESS ) {
 			rc = collectives<>::reduce( single_time, 0, operators::max< double >() );
@@ -145,8 +148,13 @@ void grbProgram( const struct input &data_in, struct output &out ) {
 		}
 		out.times.useful = single_time;
 		out.rep = static_cast< size_t >( 1000.0 / single_time ) + 1;
-		if( rc == SUCCESS ) {
+		if( rc == SUCCESS || rc == FAILED ) {
 			if( s == 0 ) {
+				if( rc == FAILED ) {
+					std::cout << "Info: cold simple_pagerank did not converge within ";
+				} else {
+					std::cout << "Info: cold simple_pagerank completed within ";
+				}
 				std::cout << "Info: cold pagerank completed within "
 					<< out.iterations << " iterations. Last computed residual is "
 					<< out.residual << ". Time taken was " << single_time

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -162,7 +162,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 grb::Launcher in automatic mode with statically sized IO,"
 			echo "                                 and uses sequential file IO in direct mode."
 			if [ -f ${INPUT_DIR}/west0497.mtx ]; then
-			$runner ${TEST_BIN_DIR}/simple_pagerank_${BACKEND} ${INPUT_DIR}/west0497.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/pagerank_out_west0497_ref &> ${TEST_OUT_DIR}/simple_pagerank_${BACKEND}_west0497_${P}_${T}.log
+			$runner ${TEST_BIN_DIR}/simple_pagerank_${BACKEND} ${INPUT_DIR}/west0497.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/pagerank_out_west0497_ref &> ${TEST_OUT_DIR}/simple_pagerank_${BACKEND}_west0497_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/simple_pagerank_${BACKEND}_west0497_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/simple_pagerank_${BACKEND}_west0497_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -190,7 +190,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"
 			echo "                                 direct-mode file IO."
 			if [ -f ${INPUT_DIR}/gyro_m.mtx ]; then
-				$runner ${TEST_BIN_DIR}/conjugate_gradient_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/conjugate_gradient_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -205,7 +205,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 variant."
 			echo "Functional test executable: ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND}"
 			if [ -f ${INPUT_DIR}/EPA.mtx ]; then
-				$runner ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log || printf 'Test FAILED.\n'
 			else
 				echo "Test DISABLED; dataset not found. Provide EPA.mtx in the ./datasets/ directory to enable."
@@ -221,7 +221,7 @@ for BACKEND in ${BACKENDS[@]}; do
 				echo "                                 verifies against a ground-truth solution vector. The test"
 				echo "                                 employs the grb::Launcher in automatic mode. It uses"
 				echo "                                 direct-mode file IO."
-				$runner ${TEST_BIN_DIR}/conjugate_gradient_complex_${BACKEND} ${TEST_DATA_DIR}/${TESTNAME}.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/complex_conjugate_conjugate_gradient_out_${TESTNAME}_ref &> ${TEST_OUT_DIR}/conjugate_gradient_complex_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/conjugate_gradient_complex_${BACKEND} ${TEST_DATA_DIR}/${TESTNAME}.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/complex_conjugate_conjugate_gradient_out_${TESTNAME}_ref &> ${TEST_OUT_DIR}/conjugate_gradient_complex_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/conjugate_gradient_complex_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/conjugate_gradient_complex_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -264,7 +264,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"
 			echo "                                 direct-mode file IO."
 			if [ -f ${INPUT_DIR}/gyro_m.mtx ]; then
-				$runner ${TEST_BIN_DIR}/bicgstab_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/bicgstab_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -276,7 +276,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 dataset (neurons=1024, layers=120, offset=294) taken from"
 			echo "                                 ${GNN_DATASET_PATH} and using thresholding 32."
 			if [ -d ${GNN_DATASET_PATH} ]; then
-				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 1 32 indirect 1 1 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_32_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 1 32 indirect 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_32_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -288,7 +288,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 dataset (neurons=1024, layers=120, offset=294) taken from"
 			echo "                                 ${GNN_DATASET_PATH} and without using thresholding."
 			if [ -d ${GNN_DATASET_PATH} ]; then
-				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 0 0 indirect 1 1 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_no_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 0 0 indirect 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_no_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -390,7 +390,7 @@ for BACKEND in ${BACKENDS[@]}; do
 				echo "                                 backend."
 				echo "Functional test executable: ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND}"
 				if [ -f ${INPUT_DIR}/EPA.mtx ]; then
-					$runner ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log
+					$runner ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log
 					grep 'Test OK' ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log || printf 'Test FAILED.\n'
 				else
 					echo "Test DISABLED; dataset not found. Provide EPA.mtx in the ./datasets/ directory to enable."

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -190,7 +190,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"
 			echo "                                 direct-mode file IO."
 			if [ -f ${INPUT_DIR}/gyro_m.mtx ]; then
-				$runner ${TEST_BIN_DIR}/conjugate_gradient_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/conjugate_gradient_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 10000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/conjugate_gradient_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -205,7 +205,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 variant."
 			echo "Functional test executable: ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND}"
 			if [ -f ${INPUT_DIR}/EPA.mtx ]; then
-				$runner ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/kcore_decomposition_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/kcore_decomposition_${BACKEND}_EPA_${P}_${T}.log || printf 'Test FAILED.\n'
 			else
 				echo "Test DISABLED; dataset not found. Provide EPA.mtx in the ./datasets/ directory to enable."
@@ -264,7 +264,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 employs the grb::Launcher in automatic mode. It uses"
 			echo "                                 direct-mode file IO."
 			if [ -f ${INPUT_DIR}/gyro_m.mtx ]; then
-				$runner ${TEST_BIN_DIR}/bicgstab_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/bicgstab_${BACKEND} ${INPUT_DIR}/gyro_m.mtx direct 1 1 10000 verification ${OUTPUT_VERIFICATION_DIR}/conjugate_gradient_out_gyro_m_ref &> ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/bicgstab_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -276,7 +276,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 dataset (neurons=1024, layers=120, offset=294) taken from"
 			echo "                                 ${GNN_DATASET_PATH} and using thresholding 32."
 			if [ -d ${GNN_DATASET_PATH} ]; then
-				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 1 32 indirect 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_32_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 1 32 indirect 1 1 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_32_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -288,7 +288,7 @@ for BACKEND in ${BACKENDS[@]}; do
 			echo "                                 dataset (neurons=1024, layers=120, offset=294) taken from"
 			echo "                                 ${GNN_DATASET_PATH} and without using thresholding."
 			if [ -d ${GNN_DATASET_PATH} ]; then
-				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 0 0 indirect 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_no_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
+				$runner ${TEST_BIN_DIR}/graphchallenge_nn_single_inference_${BACKEND} ${GNN_DATASET_PATH} 1024 120 294 0 0 indirect 1 1 verification ${OUTPUT_VERIFICATION_DIR}/graphchallenge_nn_out_1024_120_294_no_threshold_ref &> ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				head -1 ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log
 				grep 'Test OK' ${TEST_OUT_DIR}/graphchallenge_nn_single_inference_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 			else
@@ -390,7 +390,7 @@ for BACKEND in ${BACKENDS[@]}; do
 				echo "                                 backend."
 				echo "Functional test executable: ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND}"
 				if [ -f ${INPUT_DIR}/EPA.mtx ]; then
-					$runner ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 1000 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log
+					$runner ${TEST_BIN_DIR}/kcore_decomposition_critical_${BACKEND} ${INPUT_DIR}/EPA.mtx direct 1 1 verification ${OUTPUT_VERIFICATION_DIR}/kcore_decomposition_eda_ref &> ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log
 					grep 'Test OK' ${TEST_OUT_DIR}/kcore_decomposition_critical_${BACKEND}_EPA_${P}_${T}.log || printf 'Test FAILED.\n'
 				else
 					echo "Test DISABLED; dataset not found. Provide EPA.mtx in the ./datasets/ directory to enable."


### PR DESCRIPTION
As with issue #166, but now also detected for the BiCGstab smoke test, if the solver fails to converge (and thus returns the `grb::FAILED` error code), the useful time is not recorded.

This MR fixes the issue for BiCGstab, and reviews the smoke tests for all iterative solvers so to make sure the same issue does not persist elsewhere. This MR also makes uniform the implementation of all smoke tests for iterative solvers, and makes the maximum number of iterations a command-line argument for all iterative solver smoke tests. As always, it includes minor code style fixes.