### PR TITLE
275 matrix file iterator should include properties by reference

### DIFF
--- a/include/graphblas/utils/parser/matrixFileIterator.hpp
+++ b/include/graphblas/utils/parser/matrixFileIterator.hpp
@@ -742,7 +742,7 @@ namespace grb {
 				mutable size_t incs;
 				mutable bool started;
 				bool ended;
-				MatrixFileProperties properties;
+				MatrixFileProperties &properties;
 				IOMode mode;
 
 				static constexpr size_t buffer_length = config::PARSER::bsize() / 2 / sizeof( size_t );

--- a/include/graphblas/utils/parser/matrixFileReader.hpp
+++ b/include/graphblas/utils/parser/matrixFileReader.hpp
@@ -406,7 +406,10 @@ namespace grb {
 
 		/** Pretty printing function. */
 		template< typename T, typename S >
-		std::ostream & operator<<( std::ostream & out, const MatrixFileReader< T, S > & A ) {
+		std::ostream & operator<<(
+			std::ostream &out,
+			const MatrixFileReader< T, S > &A
+		) {
 			size_t nnz;
 			try {
 				nnz = A.nz();
@@ -428,9 +431,9 @@ namespace grb {
 			return out;
 		}
 
-	} // namespace utils
+	} // namespace grb::utils
 
 } // namespace grb
 
-#endif //``_H_GRB_UTILS_MATRIXFILEREADER''
+#endif // end macro ifndef _H_GRB_UTILS_MATRIXFILEREADER
 

--- a/include/graphblas/utils/parser/matrixFileReaderBase.hpp
+++ b/include/graphblas/utils/parser/matrixFileReaderBase.hpp
@@ -172,7 +172,8 @@ namespace grb {
 								// parse first non-comment non-header line
 								std::istringstream iss( line );
 								// set defaults
-								properties._m = properties._n = properties._nz = properties._entries = 0;
+								properties._m = properties._n = properties._nz = properties._entries =
+									0;
 								if( !(iss >> properties._m >> properties._n >> properties._entries) ) {
 									// could not read length line-- let a non-mtx parser try
 									mmfile = false;


### PR DESCRIPTION
The MatrixFileIterator for void-valued nonzero types copied-by-value the matrix properties. It should instead hold a reference to those properties. This manifested as a performance bug in `develop` after MR #264 that caused our internal CI to take more than 2 hours on a cursory performance test suite, instead of roughly 40 minutes.

MR #264 itself contained no issues-- all it did was include a programming pattern that kept re-creating an end-iterator, which, in turn, kept creating deep copies of the maps in the matrix file property class. Those maps furthermore are only populated when in indirect parsing mode.

This MR fixes the bug and includes code style fixes to the matrix parser files.