### PR TITLE
Wrong values printed in debug output

### DIFF
--- a/tests/utils/matrix_values_check.hpp
+++ b/tests/utils/matrix_values_check.hpp
@@ -334,7 +334,7 @@ namespace grb {
 				for( auto t = storage1.col_start[ i ]; t < storage1.col_start[ i + 1 ]; t++ ) {
 					if( storage1.row_index[ t ] != storage2.row_index[ t ] ) {
 						std::cerr << "Error: row_index[" << t << "] is different: "
-							<< storage1.row_index[ i ] << " != " << storage2.row_index[ i ]
+							<< storage1.row_index[ t ] << " != " << storage2.row_index[ t ]
 							<< std::endl;
 						return FAILED;
 					}


### PR DESCRIPTION
Likely a typo. Wrong values printed in the debug output of `compare_internal_storage`:

https://github.com/Algebraic-Programming/ALP/blob/84376d2a77d5685b88b8ce1e75e32c013866be20/tests/utils/matrix_values_check.hpp#L335-L340

Should be:

https://github.com/Algebraic-Programming/ALP/blob/f2f74f280dbd364b95f4bfa942c31b46f1efc227/tests/utils/matrix_values_check.hpp#L335-L340