### PR TITLE
Fix typo in perftests

### DIFF
--- a/tests/performance/performancetests.sh
+++ b/tests/performance/performancetests.sh
@@ -338,7 +338,7 @@ runMultiplicationKernels()
 			echo "Test DISABLED: no sparse level-3 operations recommended for 1D distributions."
 			echo " "
 		elif [ "$i" -gt "14" ]; then
-			echo "Tests DISABLED: by default, long-running sparse matrix--sparse matrix multiplications are disabled (skipping dataset ${dataSet})."
+			echo "Test DISABLED: by default, long-running sparse matrix--sparse matrix multiplications are disabled (skipping dataset ${dataSet})."
 			echo " "
 		else
 			$runner ${TEST_BIN_DIR}/driver_spmspm_${backend} ${INPUT_DIR}/${dataSet} ${INPUT_DIR}/${dataSet} ${parseMode} &> ${TEST_OUT_DIR}/driver_spmspm_${backend}_${dataSet}

--- a/tests/summarise.sh
+++ b/tests/summarise.sh
@@ -15,12 +15,14 @@ fi
 
 NUM_OK=`grep -i "Test OK" "$1" | wc -l`
 NUM_DISABLED=`grep -i "Test DISABLED" "$1" | wc -l`
+NUM_CDISABLED=`grep -i "Tests DISABLED" "$1" | wc -l`
 NUM_FAILED=`grep -i "Test FAILED" "$1" | wc -l`
 
 echo "Summary of $1:"
 printf "  %4s PASSED\n" ${NUM_OK}
 printf "  %4s SKIPPED\n" ${NUM_DISABLED}
 printf "  %4s FAILED\n" ${NUM_FAILED}
+printf "  %4s TEST CATEGORIES SKIPPED\n" ${NUM_CDISABLED}
 
 if [ ${NUM_FAILED} -gt 0 ]; then
 	printf "\nOne or more failures detected. Log contents:\n\n"


### PR DESCRIPTION
The typo in test script output caused it to not be picked up by the test summary script. In fixing this, noticed that the skipping of a test category (due to e.g. a missing data file) was not picked up by the test summary script either. This MR fixes both issues.

These bugs have had no noticeable effect on CI processes as they only affected performance tests; crossref #44 .

Closes #306 .