### PR TITLE
Fix a metabug in utils.hpp

### DIFF
--- a/include/graphblas/utils.hpp
+++ b/include/graphblas/utils.hpp
@@ -36,6 +36,10 @@
 #include <graphblas/descriptors.hpp>
 #include <graphblas/utils/iscomplex.hpp>
 
+#ifdef _DEBUG
+ #include <iostream>
+#endif
+
 
 namespace grb {
 


### PR DESCRIPTION
In a recent commit, some includes were reordered which laid bare that in `utils.hpp` and when compiling in debug mode (i.e., with the `_DEBUG` macro defined), `iostream` should have been included but was not. This MR fixes that issue.

The expected impact of this is minimal, since it is a metabug (something that only affects debug builds) *and* the time the bug was present was minimal.

Thanks to the internal CI for detecting the issue;)