### PR TITLE
Thread number configuration during runtime

### DIFF
--- a/include/graphblas/nonblocking/init.hpp
+++ b/include/graphblas/nonblocking/init.hpp
@@ -28,6 +28,7 @@
 #ifndef _H_GRB_NONBLOCKING_INIT
 #define _H_GRB_NONBLOCKING_INIT
 
+#include <omp.h>
 #include <graphblas/base/init.hpp>
 #include <graphblas/utils/DMapper.hpp>
 
@@ -134,7 +135,7 @@ namespace grb {
 				 * The maximum number of threads available in the system.
 				 */
 				static size_t numThreads() {
-					return num_threads;
+					return omp_get_max_threads();
 				}
 
 		};

--- a/src/graphblas/nonblocking/init.cpp
+++ b/src/graphblas/nonblocking/init.cpp
@@ -38,7 +38,7 @@ bool grb::internal::NONBLOCKING::warn_if_not_native = true;
 bool grb::internal::NONBLOCKING::manual_tile_size = false;
 size_t grb::internal::NONBLOCKING::manual_fixed_tile_size =
 	grb::config::ANALYTIC_MODEL::MIN_TILE_SIZE;
-size_t grb::internal::NONBLOCKING::num_threads = grb::config::OMP::threads();
+size_t grb::internal::NONBLOCKING::num_threads; // = grb::config::OMP::threads();
 
 template<>
 grb::RC grb::init< grb::nonblocking >(


### PR DESCRIPTION
This PR introduces a temporary fix to issue #351 

The idea is to get the current number of threads during runtime, every time we call the analytic model instead of getting this value once (statically before the start of the execution).

All smoke tests have passed.

Note: This is a temporary solution based on specific assumptions. Further investigation is required to ensure long-term stability and to identify a more robust fix.