### PR TITLE
151 benchmarker base does not check for errors in collective calls

### DIFF
--- a/include/graphblas/base/benchmark.hpp
+++ b/include/graphblas/base/benchmark.hpp
@@ -277,12 +277,12 @@ namespace grb {
 #endif
 
 						// pause for next outer loop
-						if( sleep( 1 ) != 0 && ret == grb::SUCCESS ) {
+						if( ret == grb::SUCCESS && sleep( 1 ) != 0 ) {
 #ifndef _GRB_NO_STDIO
 							std::cerr << "Sleep interrupted, assume benchmark is unreliable; "
 								<< "exiting.\n";
 #endif
-							abort();
+							ret = grb::FAILED;
 						}
 					}
 

--- a/include/graphblas/base/benchmark.hpp
+++ b/include/graphblas/base/benchmark.hpp
@@ -283,7 +283,7 @@ namespace grb {
 							std::cerr << "Sleep interrupted, assume benchmark is unreliable; "
 								<< "exiting.\n";
 #endif
-							ret = grb::FAILED;
+							ret = grb::PANIC;
 						}
 					}
 

--- a/include/graphblas/base/benchmark.hpp
+++ b/include/graphblas/base/benchmark.hpp
@@ -31,6 +31,7 @@
 #include <cmath>  // for sqrt
 #include <limits>
 #include <vector> // warning: normally should not be used in ALP backends(!)
+#include <unistd.h> // for sleep
 
 #ifndef _GRB_NO_STDIO
  #include <ios>

--- a/include/graphblas/base/benchmark.hpp
+++ b/include/graphblas/base/benchmark.hpp
@@ -278,12 +278,14 @@ namespace grb {
 #endif
 
 						// pause for next outer loop
-						if( ret == grb::SUCCESS && sleep( 1 ) != 0 ) {
+						if( ret == grb::SUCCESS ) {
+							if( sleep( 1 ) != 0 ) {
 #ifndef _GRB_NO_STDIO
-							std::cerr << "Sleep interrupted, assume benchmark is unreliable; "
-								<< "exiting.\n";
+								std::cerr << "Sleep interrupted, assume benchmark is unreliable; "
+									<< "exiting.\n";
 #endif
-							ret = grb::PANIC;
+								ret = grb::PANIC;
+							}
 						}
 					}
 


### PR DESCRIPTION
This should be just a simple change.
Upstream of the abort return codes seem to be correctly passed. After the condition in the loop means that the function finishes soon, so it should be fine like this.

Resolves #151 

Note: exchanged arguments in the if to avoid waiting unnecessarily if there was an error before then.