### PR TITLE
Replaced occurrences of grb::FAILED with grb::ILLEGAL 

### DIFF
--- a/include/graphblas/base/blas1.hpp
+++ b/include/graphblas/base/blas1.hpp
@@ -181,7 +181,7 @@ namespace grb {
 	 * \endcode
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -264,7 +264,7 @@ namespace grb {
 	 * \endcode
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -347,7 +347,7 @@ namespace grb {
 	 * \endcode
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -430,7 +430,7 @@ namespace grb {
 	 * \endcode
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -543,7 +543,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -652,7 +652,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -764,7 +764,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -875,7 +875,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -988,7 +988,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1099,7 +1099,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1210,7 +1210,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1321,7 +1321,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1434,7 +1434,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1546,7 +1546,7 @@ namespace grb {
 	 *                        \a z do not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1661,7 +1661,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1769,7 +1769,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1873,7 +1873,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched; it will be as though this call was never
 	 *                        made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -1980,7 +1980,7 @@ namespace grb {
 	 * @return #grb::MISMATCH Whenever the dimensions of \a y and \a z do not
 	 *                        match. All input data containers are left untouched;
 	 *                        it will be as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2087,7 +2087,7 @@ namespace grb {
 	 * @return #grb::MISMATCH Whenever the dimensions of \a x and \a z do not
 	 *                        match. All input data containers are left untouched;
 	 *                        it will be as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2190,7 +2190,7 @@ namespace grb {
 	 *                  default parameter is #grb::EXECUTE.
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2304,7 +2304,7 @@ namespace grb {
 	 *                        \a z do not match. All input data containers are left
 	 *                        untouched; it will be as though this call was never
 	 *                        made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2421,7 +2421,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched; it will be as though this call was never
 	 *                        made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2538,7 +2538,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched; it will be as though this call was never
 	 *                        made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2651,7 +2651,7 @@ namespace grb {
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
 	 * @return #grb::MISMATCH If \a mask and \a z do not have the same size.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2746,7 +2746,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2843,7 +2843,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -2940,7 +2940,7 @@ namespace grb {
 	 *                        match. All input data containers are left untouched
 	 *                        if this exit code is returned; it will be as though
 	 *                        this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -3033,7 +3033,7 @@ namespace grb {
 	 *                  default parameter is #grb::EXECUTE.
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -3132,7 +3132,7 @@ namespace grb {
 	 *                        \a z do not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -3237,7 +3237,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -3342,7 +3342,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.
@@ -3444,7 +3444,7 @@ namespace grb {
 	 *
 	 * @return #grb::SUCCESS  On successful completion of this call.
 	 * @return #grb::MISMATCH If \a mask and \a z have different size.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output vector
 	 *                        \a z is cleared, and the call to this function has no
 	 *                        further effects.

--- a/include/graphblas/base/blas3.hpp
+++ b/include/graphblas/base/blas3.hpp
@@ -157,7 +157,7 @@ namespace grb {
 	 *                        nonzeroes as \a x.
 	 * @return #grb::ILLEGAL  If \a y or \a z has a different sparsity pattern from
 	 *                        \a x.
-	 * @return #grb::FAILED   If the capacity of \a A was insufficient to store the
+	 * @return #grb::ILLEGAL  If the capacity of \a A was insufficient to store the
 	 *                        given sparsity pattern and \a phase is #grb::EXECUTE.
 	 * @return #grb::OUTOFMEM If the \a phase is #grb::RESIZE and \a A could not be
 	 *                        resized to have sufficient capacity to complete this
@@ -288,7 +288,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output matrix
 	 *                        \a z is cleared, and the call to this function has
 	 *                        no further effects.
@@ -387,7 +387,7 @@ namespace grb {
 	 *                        not match. All input data containers are left
 	 *                        untouched if this exit code is returned; it will be
 	 *                        be as though this call was never made.
-	 * @return #grb::FAILED   If \a phase is #grb::EXECUTE, indicates that the
+	 * @return #grb::ILLEGAL  If \a phase is #grb::EXECUTE, indicates that the
 	 *                        capacity of \a z was insufficient. The output
 	 *                        matrix \a z is cleared, and the call to this function
 	 *                        has no further effects.

--- a/include/graphblas/base/io.hpp
+++ b/include/graphblas/base/io.hpp
@@ -866,7 +866,7 @@ namespace grb {
 	 *
 	 * In #grb::EXECUTE mode:
 	 *
-	 * @returns #grb::ILLEGAL  When \a x did not have sufficient capacity. The
+	 * @returns #grb::ILLEGAL When \a x did not have sufficient capacity. The
 	 *                        vector \a x on exit shall be cleared.
 	 * @returns #grb::SUCCESS When the call completes successfully.
 	 *
@@ -893,7 +893,8 @@ namespace grb {
 		typename Coords, Backend backend
 	>
 	RC set(
-		Vector< DataType, backend, Coords > &x, const T val,
+		Vector< DataType, backend, Coords > &x,
+		const T val,
 		const Phase &phase = EXECUTE,
 		const typename std::enable_if<
 			!grb::is_object< DataType >::value &&

--- a/include/graphblas/base/io.hpp
+++ b/include/graphblas/base/io.hpp
@@ -866,13 +866,13 @@ namespace grb {
 	 *
 	 * In #grb::EXECUTE mode:
 	 *
-	 * @returns #grb::FAILED  When \a x did not have sufficient capacity. The
+	 * @returns #grb::ILLEGAL  When \a x did not have sufficient capacity. The
 	 *                        vector \a x on exit shall be cleared.
 	 * @returns #grb::SUCCESS When the call completes successfully.
 	 *
 	 * In #grb::TRY mode (experimental and may not be supported):
 	 *
-	 * @returns #grb::FAILED  When \a x did not have sufficient capacity. The
+	 * @returns #grb::ILLEGAL When \a x did not have sufficient capacity. The
 	 *                        vector \a x on exit will have contents defined as
 	 *                        described for #grb::TRY.
 	 * @returns #grb::SUCCESS When the call completes successfully.
@@ -950,13 +950,13 @@ namespace grb {
 	 *
 	 * In #grb::EXECUTE mode:
 	 *
-	 * @returns #grb::FAILED  When \a x did not have sufficient capacity. The
+	 * @returns #grb::ILLEGAL When \a x did not have sufficient capacity. The
 	 *                        vector \a x on exit shall be cleared.
 	 * @returns #grb::SUCCESS When the call completes successfully.
 	 *
 	 * In #grb::TRY mode (experimental and may not be supported):
 	 *
-	 * @returns #grb::FAILED  When \a x did not have sufficient capacity. The
+	 * @returns #grb::ILLEGAL When \a x did not have sufficient capacity. The
 	 *                        vector \a x on exit will have contents defined as
 	 *                        described for #grb::TRY.
 	 * @returns #grb::SUCCESS When the call completes successfully.

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -71,7 +71,8 @@ namespace grb {
 		template< bool isgd, typename T >
 		void handle_try_execute(
 			grb::Vector< T > &x,
-			const grb::Phase &phase, grb::RC &ret
+			const grb::Phase &phase,
+			grb::RC &ret
 		) {
 			// handle try and execute
 			if( phase != RESIZE ) {
@@ -442,18 +443,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				internal::setDense( y );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( y );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// otherwise, still return FAILED (as required)
-			}
-		}
+		grb::internal::handle_try_execute< true >( y, phase, ret );
 
 		// done
 		return ret;
@@ -1807,22 +1797,7 @@ namespace grb {
 		}
 
 		// catch execute
-		if( phase != RESIZE ) {
-			if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() && 
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			} else if( ret == SUCCESS ) {
-				if( !(descr & descriptors::dense) ) {
-					ret = internal::updateNnz( z );
-				} else {
-					internal::setDense( z );
-				}
-			}
-		}
+		grb::internal::handle_try_execute< descriptors::dense == (descr & descriptors::dense) >( z, phase, ret );
 
 		// done
 		return ret;

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -1798,7 +1798,7 @@ namespace grb {
 
 		// catch execute
 		internal::template handle_try_execute<
-				(descr & descriptors::dense)
+				((descr & descriptors::dense) > 0)
 			>( z, phase, ret );
 
 		// done

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -53,6 +53,34 @@
 
 namespace grb {
 
+	namespace internal {
+
+		/*
+		 * Handle try and execute phases return code
+		 */
+		template< typename T >
+		grb::RC handle_try_execute( grb::Vector< T > &x, const grb::Phase phase, const grb::RC ret ){
+			// handle try and execute
+			if( phase != RESIZE ) {
+				if( ret == SUCCESS ) {
+					// in this case, the number of nonzeroes in the output vector may have
+					// changed (recall that the dense case is not handled here)
+					return internal::updateNnz( x );
+				} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+					ret == FAILED
+				) {
+					// in this case, the full computation has not completed but the contents of
+					// x do contain a subset of results. Therefore, the number of nonzeroes may
+					// have changed, but we need to take care to still propagate FAILED
+					const RC subrc = internal::updateNnz( x );
+					if( subrc != SUCCESS ) { return grb::PANIC; }
+				}
+			}
+			return ret;
+		}
+
+	}
+
 	/**
 	 * \defgroup BLAS1_REF The Level-1 ALP/GraphBLAS routines -- BSP1D backend
 	 *
@@ -684,18 +712,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				internal::setDense( x );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed try
-				const RC subrc = internal::updateNnz( x );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// ensure we still propagate the FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( x, phase, ret );
 
 		// done
 		return ret;
@@ -1019,20 +1036,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				// x may have a new global number of nonzeroes that needs to be synced
-				// (recall that the dense case is not handled here)
-				ret = internal::updateNnz( x );
-			} else if( ret == FAILED ) {
-				// handle failed TRY
-				// x may contain useful results that are a subset of the requested
-				// computation. Therefore the nnz may have changed, but we should
-				// take care to continue propagate FAILED
-				const RC subrc = internal::updateNnz( x );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-			}
-		}
+		ret = handle_try_execute( x, phase, ret );
 
 		// done
 		return ret;
@@ -1112,18 +1116,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( x );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( x );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// ensure propagate FAILED error code
-			}
-		}
+		ret = handle_try_execute( x, phase, ret );
 
 		// done
 		return ret;
@@ -1203,18 +1196,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( x );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handled failed TRY
-				const RC subrc = internal::updateNnz( x );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// ensure FAILED error code propagates
-			}
-		}
+		ret = grb::internal::handle_try_execute( x, phase, ret );
 
 		// done
 		return ret;
@@ -1917,18 +1899,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2022,18 +1993,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2138,19 +2098,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			}
-			if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC update_rc = internal::updateNnz( z );
-				if( update_rc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2236,19 +2184,8 @@ namespace grb {
 		}
 
 		// handle execute phase
-		if( phase != RESIZE ) {
-			assert( phase == EXECUTE );
-			if( ret == SUCCESS ) {
-				internal::setDense( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
+
 		return ret;
 	}
 
@@ -2332,19 +2269,7 @@ namespace grb {
 		}
 
 		// handle execute
-		if( phase != RESIZE ) {
-			assert( phase == EXECUTE );
-			if( ret == SUCCESS ) {
-				internal::setDense( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2438,18 +2363,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate original error code (FAILED)
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2543,18 +2457,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED erro code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2654,18 +2557,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -2765,18 +2657,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// propagate FAILED error code
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3330,18 +3211,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// take care to propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3414,18 +3284,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3497,18 +3356,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = FAILED; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3663,18 +3511,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3760,18 +3597,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = PANIC; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3857,18 +3683,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = FAILED; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;
@@ -3951,18 +3766,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		if( phase != RESIZE ) {
-			if( ret == SUCCESS ) {
-				ret = internal::updateNnz( z );
-			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
-				ret == FAILED
-			) {
-				// handle failed TRY
-				const RC subrc = internal::updateNnz( z );
-				if( subrc != SUCCESS ) { ret = FAILED; }
-				// propagate FAILED
-			}
-		}
+		ret = grb::internal::handle_try_execute( z, phase, ret );
 
 		// done
 		return ret;

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -443,7 +443,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		grb::internal::handle_try_execute< true >( y, phase, ret );
+		internal::template handle_try_execute< true >( y, phase, ret );
 
 		// done
 		return ret;
@@ -1797,7 +1797,9 @@ namespace grb {
 		}
 
 		// catch execute
-		grb::internal::handle_try_execute< descriptors::dense == (descr & descriptors::dense) >( z, phase, ret );
+		internal::template handle_try_execute<
+				(descr & descriptors::dense)
+			>( z, phase, ret );
 
 		// done
 		return ret;

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -56,16 +56,35 @@ namespace grb {
 	namespace internal {
 
 		/*
-		 * Handle try and execute phases return code
+		 * Handles TRY and EXECUTE phases return code and associated global
+		 * updates.
+		 *
+		 * This helper function applies to both cases when
+		 *  -# on SUCCESS, the output vector becomes dense;
+		 *  -# on FAILED, the output vector global nonzero count needs
+		 *     updating.
+		 *
+		 * @tparam isgd If on SUCCESS, the Global output vector is
+		 *              guaranteed Dense (ISGD).
+		 * @tparam T    The value type of the output vector
 		 */
-		template< typename T >
-		grb::RC handle_try_execute( grb::Vector< T > &x, const grb::Phase phase, const grb::RC ret ){
+		template< bool isgd, typename T >
+		void handle_try_execute(
+			grb::Vector< T > &x,
+			const grb::Phase &phase, grb::RC &ret
+		) {
 			// handle try and execute
 			if( phase != RESIZE ) {
 				if( ret == SUCCESS ) {
-					// in this case, the number of nonzeroes in the output vector may have
-					// changed (recall that the dense case is not handled here)
-					return internal::updateNnz( x );
+					if( isgd ) {
+						// in this case, the number of nonzeroes in the output vector is
+						// guaranteed full - no communication required
+						internal::setDense( x );
+					} else {
+						// in this case, the number of nonzeroes in the output vector may have
+						// changed
+						ret = internal::updateNnz( x );
+					}
 				} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
 					ret == FAILED
 				) {
@@ -73,13 +92,12 @@ namespace grb {
 					// x do contain a subset of results. Therefore, the number of nonzeroes may
 					// have changed, but we need to take care to still propagate FAILED
 					const RC subrc = internal::updateNnz( x );
-					if( subrc != SUCCESS ) { return grb::PANIC; }
+					if( subrc != SUCCESS ) { ret = grb::PANIC; }
 				}
 			}
-			return ret;
 		}
 
-	}
+	} // end namespace ``grb::internal''
 
 	/**
 	 * \defgroup BLAS1_REF The Level-1 ALP/GraphBLAS routines -- BSP1D backend
@@ -711,8 +729,8 @@ namespace grb {
 			}
 		}
 
-		// handle try and execute
-		ret = grb::internal::handle_try_execute( x, phase, ret );
+		// handle try and execute phases
+		internal::template handle_try_execute< true >( x, phase, ret );
 
 		// done
 		return ret;
@@ -1036,7 +1054,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		ret = handle_try_execute( x, phase, ret );
+		internal::template handle_try_execute< false >( x, phase, ret );
 
 		// done
 		return ret;
@@ -1116,7 +1134,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = handle_try_execute( x, phase, ret );
+		internal::template handle_try_execute< false >( x, phase, ret );
 
 		// done
 		return ret;
@@ -1196,7 +1214,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( x, phase, ret );
+		internal::template handle_try_execute< false >( x, phase, ret );
 
 		// done
 		return ret;
@@ -1899,7 +1917,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -1993,7 +2011,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2098,7 +2116,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2184,7 +2202,7 @@ namespace grb {
 		}
 
 		// handle execute phase
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< true >( z, phase, ret );
 
 		return ret;
 	}
@@ -2269,7 +2287,7 @@ namespace grb {
 		}
 
 		// handle execute
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< true >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2363,7 +2381,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2457,7 +2475,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2557,7 +2575,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -2657,7 +2675,7 @@ namespace grb {
 		}
 
 		// handle try and execute
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3211,7 +3229,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3284,7 +3302,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3356,7 +3374,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3511,7 +3529,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3597,7 +3615,7 @@ namespace grb {
 		}
 
 		// handle execute and try phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3683,7 +3701,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;
@@ -3766,7 +3784,7 @@ namespace grb {
 		}
 
 		// handle try and execute phases
-		ret = grb::internal::handle_try_execute( z, phase, ret );
+		internal::template handle_try_execute< false >( z, phase, ret );
 
 		// done
 		return ret;

--- a/include/graphblas/bsp1d/blas1.hpp
+++ b/include/graphblas/bsp1d/blas1.hpp
@@ -23,15 +23,15 @@
 #ifndef _H_GRB_BSP1D_BLAS1
 #define _H_GRB_BSP1D_BLAS1
 
+#include <graphblas/rc.hpp>
+#include <graphblas/ops.hpp>
 #include <graphblas/blas0.hpp>
 #include <graphblas/blas1.hpp>
 #include <graphblas/bsp/collectives.hpp>
-#include <graphblas/ops.hpp>
-#include <graphblas/rc.hpp>
 #include <graphblas/type_traits.hpp>
 
-#include "distribution.hpp"
 #include "vector.hpp"
+#include "distribution.hpp"
 
 #define NO_CAST_ASSERT( x, y, z )                                                          \
 	static_assert( x,                                                                  \
@@ -402,8 +402,10 @@ namespace grb {
 			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
 				ret == FAILED
 			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( y );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// otherwise, still return FAILED (as required)
 			}
 		}
 
@@ -685,9 +687,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				internal::setDense( x );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed try
 				const RC subrc = internal::updateNnz( x );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// ensure we still propagate the FAILED error code
 			}
 		}
 
@@ -846,10 +852,13 @@ namespace grb {
 					const RC subrc = internal::updateNnz( x );
 					if( subrc != SUCCESS ) { ret = PANIC; }
 				}
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
 				assert( phase == TRY );
 				const RC subrc = internal::updateNnz( x );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// ensure propagate failed error code
 			}
 		}
 
@@ -1016,6 +1025,7 @@ namespace grb {
 				// (recall that the dense case is not handled here)
 				ret = internal::updateNnz( x );
 			} else if( ret == FAILED ) {
+				// handle failed TRY
 				// x may contain useful results that are a subset of the requested
 				// computation. Therefore the nnz may have changed, but we should
 				// take care to continue propagate FAILED
@@ -1105,9 +1115,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( x );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( x );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// ensure propagate FAILED error code
 			}
 		}
 
@@ -1192,9 +1206,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( x );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handled failed TRY
 				const RC subrc = internal::updateNnz( x );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// ensure FAILED error code propagates
 			}
 		}
 
@@ -1249,7 +1267,12 @@ namespace grb {
 			return ILLEGAL;
 		}
 		if( capacity( z ) < n && phase == EXECUTE ) {
-			return FAILED;
+			const grb::RC clear_rc = grb::clear( z );
+			if( clear_rc == grb::SUCCESS ) {
+				return ILLEGAL;
+			} else {
+				return PANIC;
+			}
 		}
 
 		// catch trivial resize
@@ -1326,8 +1349,13 @@ namespace grb {
 		if( size( mask ) != n ) {
 			return MISMATCH;
 		}
-		if( capacity( z ) < n && phase == EXECUTE ) {
-			return FAILED;
+		if( grb::capacity( z ) < n && phase == grb::EXECUTE ) {
+			const grb::RC clear_rc = grb::clear( z );
+			if( clear_rc == grb::SUCCESS ) {
+				return grb::ILLEGAL;
+			} else {
+				return grb::PANIC;
+			}
 		}
 
 		// catch trivial resize
@@ -1393,8 +1421,13 @@ namespace grb {
 		if( (descr & descriptors::dense) && nnz( z ) != n ) {
 			return ILLEGAL;
 		}
-		if( capacity( z ) < n && phase == EXECUTE ) {
-			return FAILED;
+		if( grb::capacity( z ) < n && phase == grb::EXECUTE ) {
+			const grb::RC clear_rc = grb::clear( z );
+			if( clear_rc == grb::SUCCESS ) {
+				return grb::ILLEGAL;
+			} else {
+				return grb::PANIC;
+			}
 		}
 
 		// catch trivial resize
@@ -1471,8 +1504,13 @@ namespace grb {
 		if( size( mask ) != n ) {
 			return MISMATCH;
 		}
-		if( capacity( z ) < n && phase == EXECUTE ) {
-			return FAILED;
+		if( grb::capacity( z ) < n && phase == grb::EXECUTE ) {
+			const grb::RC clear_rc = grb::clear( z );
+			if( clear_rc == grb::SUCCESS ) {
+				return grb::ILLEGAL;
+			} else {
+				return grb::PANIC;
+			}
 		}
 
 		// catch trivial resize
@@ -1572,8 +1610,8 @@ namespace grb {
 		} else if( phase == EXECUTE ) {
 			if( ret == SUCCESS ) {
 				internal::setDense( z );
-			} else if( ret == FAILED ) {
-				const RC subrc = internal::updateNnz( z );
+			} else if( ret == ILLEGAL ) {
+				const RC subrc = grb::clear( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
 			}
 		}
@@ -1662,8 +1700,8 @@ namespace grb {
 		} else if( phase == EXECUTE ) {
 			if( ret == SUCCESS ) {
 				internal::setDense( z );
-			} else if( ret == FAILED ) {
-				const RC subrc = internal::updateNnz( z );
+			} else if( ret == ILLEGAL ) {
+				const RC subrc = grb::clear( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
 			}
 		}
@@ -1770,10 +1808,13 @@ namespace grb {
 
 		// catch execute
 		if( phase != RESIZE ) {
-			assert( phase == EXECUTE );
-			if( ret == FAILED ) {
+			if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() && 
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			} else if( ret == SUCCESS ) {
 				if( !(descr & descriptors::dense) ) {
 					ret = internal::updateNnz( z );
@@ -1879,9 +1920,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 
@@ -1980,9 +2025,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 
@@ -2093,9 +2142,13 @@ namespace grb {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
 			}
-			if( ret == FAILED ) {
+			if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC update_rc = internal::updateNnz( z );
 				if( update_rc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 
@@ -2187,9 +2240,13 @@ namespace grb {
 			assert( phase == EXECUTE );
 			if( ret == SUCCESS ) {
 				internal::setDense( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 		return ret;
@@ -2279,9 +2336,13 @@ namespace grb {
 			assert( phase == EXECUTE );
 			if( ret == SUCCESS ) {
 				internal::setDense( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 
@@ -2380,9 +2441,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate original error code (FAILED)
 			}
 		}
 
@@ -2481,9 +2546,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED erro code
 			}
 		}
 
@@ -2588,9 +2657,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED error code
 			}
 		}
 
@@ -2695,9 +2768,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// propagate FAILED error code
 			}
 		}
 
@@ -3256,9 +3333,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// take care to propagate FAILED
 			}
 		}
 
@@ -3336,9 +3417,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// propagate FAILED
 			}
 		}
 
@@ -3415,9 +3500,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = FAILED; }
+				// propagate FAILED
 			}
 		}
 
@@ -3577,9 +3666,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// propagate FAILED
 			}
 		}
 
@@ -3670,9 +3763,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = PANIC; }
+				// propagate FAILED
 			}
 		}
 
@@ -3763,9 +3860,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = FAILED; }
+				// propagate FAILED
 			}
 		}
 
@@ -3853,9 +3954,13 @@ namespace grb {
 		if( phase != RESIZE ) {
 			if( ret == SUCCESS ) {
 				ret = internal::updateNnz( z );
-			} else if( ret == FAILED ) {
+			} else if( !config::IMPLEMENTATION< BSP1D >::fixedVectorCapacities() &&
+				ret == FAILED
+			) {
+				// handle failed TRY
 				const RC subrc = internal::updateNnz( z );
 				if( subrc != SUCCESS ) { ret = FAILED; }
+				// propagate FAILED
 			}
 		}
 

--- a/include/graphblas/bsp1d/init.hpp
+++ b/include/graphblas/bsp1d/init.hpp
@@ -23,7 +23,8 @@
 #ifndef _H_GRB_BSP1D_INIT
 #define _H_GRB_BSP1D_INIT
 
-#include <vector> //queue of HP put and get requests
+#include <vector> // for queue of HP put and get requests
+#include <cstdint> // for uintptr_t
 
 #include "config.hpp"
 

--- a/include/graphblas/bsp1d/io.hpp
+++ b/include/graphblas/bsp1d/io.hpp
@@ -1625,8 +1625,12 @@ namespace grb {
 			// a pipeline depth of 2 is sufficient.
 			constexpr size_t iteration_overlaps = 2;
 
-			const std::unique_ptr< size_t > first_nnz_per_thread(
-				new size_t[ num_threads * iteration_overlaps ]()
+			const std::unique_ptr<
+				size_t,
+				std::function<void(const size_t * const)>
+			> first_nnz_per_thread(
+				new size_t[ num_threads * iteration_overlaps ](),
+				[](const size_t * const toFree){ delete [] toFree; }
 			);
 			size_t * const first_nnz_per_thread_ptr = first_nnz_per_thread.get();
 			outgoing.resize( data.P );

--- a/include/graphblas/phase.hpp
+++ b/include/graphblas/phase.hpp
@@ -154,37 +154,41 @@ namespace grb {
 	enum Phase {
 
 		/**
-		 * Speculatively assumes that the output container(s) of the requested
-		 * operation lack the necessary capacity to hold all outputs of the
-		 * computation. Instead of executing the requested operation, this phase
-		 * attempts to both estimate and resize the output container(s).
+		 * Assumes that the output container(s) of the requested operation may lack
+		 * the required capacity to hold all outputs of the requested computation.
+		 *
+		 * Instead of executing the requested operation, this phase attempts to both
+		 * estimate and resize the output container(s).
 		 *
 		 * A successful call using this phase guarantees that a subsequent and
 		 * equivalent call using the #grb::EXECUTE phase shall be successful.
 		 *
-		 * Here, an <em>equivalent call</em> means that the operation must be called
-		 * with exactly the same arguments, except for the #grb::Phase argument.
+		 * Here,
+		 *  -# an <em>equivalent call</em> means that the operation must be called
+		 *     with exactly the same arguments except for the #grb::Phase argument;
+		 *  -# a <em>subsequent</em> call means that all involved containers are not
+		 *     nonzero-structure-altering outputs of any other ALP primitive prior to
+		 *     the call that requests the execute phase.
 		 *
-		 * Here, <em>subsequent</em> means that all involved containers are not
-		 * arguments to any other ALP/GraphBLAS primitives prior to the final call
-		 * that requests the execute phase.
-		 *
-		 * Different from #grb::resize, calling operations using the resize phase does
-		 * \em not modify the contents of output containers, and may only enlargen
-		 * capacities-- not shrink them.
+		 * Different from #grb::EXECUTE, calling primitives with the resize phase does
+		 * \em not modify the contents of output containers. Furthermore, the call may
+		 * only enlargen the capacity of output containers-- not shrink them.
 		 *
 		 * \note This specification does \em not disallow implementations or backends
 		 *       that perform part of the computation during the resize phase. Any
-		 *       such behaviour is totally optional for implementations and backends.
-		 *       However, any progress made in such manner must remain hidden from the
-		 *       user since output container contents must not be modified by
-		 *       primitives executing a resize phase.
+		 *       such behaviour is optional for implementations and backends. However,
+		 *       any such intermediate progress made must remain hidden from the user
+		 *       until a call with an execute phase passes.
 		 *
 		 * A backend must define clear performance semantics for each primitive and
 		 * for each phase that primitive can be called with. In particular, backends
 		 * must specify whether system calls such as dynamic memory allocations or
 		 * frees may occur, and whether primtives operating in a resize phase may
 		 * return #grb::OUTOFMEM.
+		 *
+		 * \note Both of these (may make dynamic allocations and may return
+		 *       #grb::OUTOFMEM would be expected from resize phases for most
+		 *       implementations.
 		 */
 		RESIZE,
 
@@ -193,15 +197,16 @@ namespace grb {
 		 * has enough capacity to complete the computation, and attempts to do so.
 		 *
 		 * If the capacity was indeed found to be sufficient, then the computation
-		 * \em must complete as specified-- unless #grb::PANIC is returned.
+		 * \em must complete as specified.
 		 *
 		 * If, nevertheless, capacity was not sufficient then the result of the
-		 * computation is incomplete and the primitive shall return #grb::ILLEGAL.
+		 * computation is incomplete and the primitive shall return #grb::FAILED.
 		 * Regarding each output container \a A, the following are guaranteed:
 		 *    -# the capacity of \a A remains unchanged;
-		 *    -# contains #grb::capacity (of \a A) nonzeroes;
-		 *    -# has nonzeroes at the coordinates where \a A on entry had nonzeroes;
-		 *    -# has nonzeroes with values equal to those that would have been
+		 *    -# contains that number of nonzeroes (i.e., reaches full capacity);
+		 *    -# has <em>at minimum</em> nonzeroes at the coordinates where \a A on
+		 *       entry had nonzeroes;
+		 *    -# every nonzero has values equal to those that would have been
 		 *       computed at its coordinates were the call successul; and
 		 *    -# does not contain all nonzeroes that would have been present in \a A
 		 *       were the call successful (or otherwise #grb::SUCCESS would have been
@@ -212,8 +217,7 @@ namespace grb {
 		 *          full output without re-initiating the full computation. In other
 		 *          words, this mechanism does not allow for the partial computation
 		 *          to complete the remainder computation using less effort than the
-		 *          full computation would have required. This is the main difference
-		 *          with the #grb::EXECUTE phase.
+		 *          full computation would have required.
 		 *
 		 * \note This phase is particularly useful if partial output is still usable
 		 *       and recomputation to generate the full output is not required.
@@ -222,7 +226,8 @@ namespace grb {
 		 * for each phase that primitive can be called with.
 		 *
 		 * \warning The <tt>try</tt> phase is current experimental and \em not broadly
-		 *          supported in the reference implementation.
+		 *          supported in the reference implementation, nor within any other
+		 *          public backend implementation.
 		 */
 		TRY,
 
@@ -236,15 +241,16 @@ namespace grb {
 		 * execute phase.
 		 *
 		 * If, instead, the output container capacity was found to be insufficient,
-		 * then the requested operation may return #grb::ILLEGAL, in which case the
+		 * then the requested operation returns #grb::ILLEGAL, in which case the
 		 * contents of output containers shall be cleared.
 		 *
 		 * \note That on failure a primitive called using the execute phase may
-		 *       destroy any pre-existing contents of output containers is a critical
-		 *       difference with the #grb::TRY phase.
+		 *       destroy any pre-existing contents of output containers. This is a
+		 *       critical difference to the proposed not-yet-pervasively-available
+		 *       #grb::TRY phase.
 		 *
-		 * \warning When calling ALP/GraphBLAS primitives without specifying a phase
-		 *          explicitly, this execute phase will be assumed by default.
+		 * \warning When calling ALP primitives without specifying an explicit phase,
+		 *          this execute phase will be assumed by default.
 		 *
 		 * A backend must define clear performance semantics for each primitive and
 		 * for each phase that primitive can be called with. In particular, backends
@@ -253,8 +259,9 @@ namespace grb {
 		 * return #grb::OUTOFMEM.
 		 *
 		 * \note Typically, implementations and backends are advised to specify no
-		 *       system calls and in particular dynamic memory management calls are
-		 *       allowed as part of an execute phase.
+		 *       system calls for the execute phase of any ALP primitive -- in
+		 *       particular, dynamic memory management calls should not be allowed as
+		 *       part of an execute phase.
 		 */
 		EXECUTE
 

--- a/include/graphblas/phase.hpp
+++ b/include/graphblas/phase.hpp
@@ -196,7 +196,7 @@ namespace grb {
 		 * \em must complete as specified-- unless #grb::PANIC is returned.
 		 *
 		 * If, nevertheless, capacity was not sufficient then the result of the
-		 * computation is incomplete and the primitive shall return #grb::FAILED.
+		 * computation is incomplete and the primitive shall return #grb::ILLEGAL.
 		 * Regarding each output container \a A, the following are guaranteed:
 		 *    -# the capacity of \a A remains unchanged;
 		 *    -# contains #grb::capacity (of \a A) nonzeroes;
@@ -236,7 +236,7 @@ namespace grb {
 		 * execute phase.
 		 *
 		 * If, instead, the output container capacity was found to be insufficient,
-		 * then the requested operation may return #grb::FAILED, in which case the
+		 * then the requested operation may return #grb::ILLEGAL, in which case the
 		 * contents of output containers shall be cleared.
 		 *
 		 * \note That on failure a primitive called using the execute phase may

--- a/include/graphblas/reference/blas3.hpp
+++ b/include/graphblas/reference/blas3.hpp
@@ -1700,12 +1700,12 @@ namespace grb {
 
 			if( clear_at_exit ) {
 #ifdef _DEBUG_REFERENCE_BLAS3
-				std::cout << "\t mxm_generic is about to exit with FAILED "
+				std::cout << "\t mxm_generic is about to exit with ILLEGAL "
 					<< "(and will clear the output matrix)\n";
 #endif
 				const RC clear_rc = clear( C );
 				if( clear_rc != SUCCESS ) { return PANIC; }
-				return FAILED;
+				return ILLEGAL;
 			}
 
 #ifdef _DEBUG_REFERENCE_BLAS3
@@ -1888,7 +1888,7 @@ namespace grb {
 					<< "complete the requested computation\n";
 #endif
 				if( clear_rc == SUCCESS ) {
-					return FAILED;
+					return ILLEGAL;
 				} else {
 					return PANIC;
 				}
@@ -2043,7 +2043,12 @@ namespace grb {
 			// step 4, check nonzero capacity
 			assert( crs_offsets[ nrows ] == ccs_offsets[ ncols ] );
 			if( internal::getNonzeroCapacity( A ) < crs_offsets[ nrows ] ) {
-				return FAILED;
+				const grb::RC clear_rc = grb::clear( A );
+				if( clear_rc == grb::SUCCESS ) {
+					return grb::ILLEGAL;
+				} else {
+					return grb::PANIC;
+				}
 			}
 
 			// step 5, counting sort, second and final ingestion phase
@@ -2252,7 +2257,10 @@ namespace grb {
 		if( ncols != grb::ncols( A ) ) {
 			return MISMATCH;
 		}
-
+		if( std::numeric_limits< size_t >::max() / nnz( u ) < nnz( v ) ||
+			std::numeric_limits< size_t >::max() / nnz( v ) < nnz( u ) ) {
+			return ILLEGAL;
+		}
 		if( phase == RESIZE ) {
 			return resize( A, nnz( u ) * nnz( v ) );
 		}
@@ -2267,7 +2275,7 @@ namespace grb {
 			if( clear_rc != SUCCESS ) {
 				return PANIC;
 			} else {
-				return FAILED;
+				return ILLEGAL;
 			}
 		}
 
@@ -2835,7 +2843,7 @@ namespace grb {
 					if( clear_rc != SUCCESS ) {
 						return PANIC;
 					} else {
-						return FAILED;
+						return ILLEGAL;
 					}
 				}
 

--- a/include/graphblas/reference/compressed_storage.hpp
+++ b/include/graphblas/reference/compressed_storage.hpp
@@ -1156,7 +1156,7 @@ namespace grb {
 				{}
 
 				/** Move constructor. */
-				Compressed_Storage< void, IND, SIZE >( SelfType &&other ) {
+				Compressed_Storage( SelfType &&other ) {
 					moveFromOther( other );
 				}
 

--- a/include/graphblas/utils/parser/matrixFileReaderBase.hpp
+++ b/include/graphblas/utils/parser/matrixFileReaderBase.hpp
@@ -280,7 +280,8 @@ namespace grb {
 						properties._nz = nz;
 						properties._entries = entries;
 						properties._pattern = pattern;
-						properties._symmetric = symmetric;
+						properties._symmetric = symmetric
+							? Symmetry::Symmetric : Symmetry::General;
 						properties._direct = direct;
 						properties._symmetricmap = symmetricmap;
 						// check for existance of file


### PR DESCRIPTION
Solves #374

It seems that the issue was only in the documentation. Now `GRB::FAILED` appears only in tests, benchmark and algorithms, as should be the case