### PR TITLE
Fixing creation of `grb::Vector<reference>` with bsp1d backend

### DIFF
--- a/src/graphblas/reference/init.cpp
+++ b/src/graphblas/reference/init.cpp
@@ -62,6 +62,7 @@ grb::RC grb::init< grb::reference >(
 	// set memory policy
 	numa_set_localalloc();
 #endif
+	grb::internal::reference_mapper.clear();
 	// done
 	return grb::SUCCESS;
 }


### PR DESCRIPTION
Resolves #403 

The issue seems to be that reference_mapper was not correctly initialized. Its constructor was called only for process 0. 

@anyzelman should I also add a test for to check that there is no issue like this in the future? 