### PR TITLE
HyperDAG data handleing for hpcg 

### DIFF
--- a/include/graphblas/base/benchmark.hpp
+++ b/include/graphblas/base/benchmark.hpp
@@ -105,9 +105,9 @@ namespace grb {
 					const auto now = std::chrono::system_clock::now();
 					const auto since = now.time_since_epoch();
 					if( printHeader ) {
-						std::cout << "Time since epoch (in ms.): ";
-					}
-					std::cout << std::chrono::duration_cast<
+					std::cerr << "Time since epoch (in ms.): ";
+				}
+				std::cerr << std::chrono::duration_cast<
 							std::chrono::milliseconds
 						>( since ).count() << "\n";
 				}
@@ -164,18 +164,18 @@ namespace grb {
 #ifndef _GRB_NO_STDIO
 					// output results
 					if( pid == 0 ) {
-						std::cout << "Overall timings (io, preamble, useful, postamble):\n"
+						std::cerr << "Overall timings (io, preamble, useful, postamble):\n"
 							<< std::scientific;
-						std::cout << "Avg: " << total_times.io << ", " << total_times.preamble
+						std::cerr << "Avg: " << total_times.io << ", " << total_times.preamble
 							<< ", " << total_times.useful << ", " << total_times.postamble << "\n";
-						std::cout << "Min: " << min_times.io << ", " << min_times.preamble << ", "
+						std::cerr << "Min: " << min_times.io << ", " << min_times.preamble << ", "
 							<< min_times.useful << ", " << min_times.postamble << "\n";
-						std::cout << "Max: " << max_times.io << ", " << max_times.preamble << ", "
+						std::cerr << "Max: " << max_times.io << ", " << max_times.preamble << ", "
 							<< max_times.useful << ", " << max_times.postamble << "\n";
-						std::cout << "Std: " << sqrt( sdev.io ) << ", " << sqrt( sdev.preamble )
+						std::cerr << "Std: " << sqrt( sdev.io ) << ", " << sqrt( sdev.preamble )
 							<< ", " << sqrt( sdev.useful ) << ", " << sqrt( sdev.postamble ) << "\n";
  #if __GNUC__ > 4
-						std::cout << std::defaultfloat;
+						std::cerr << std::defaultfloat;
  #endif
 						printTimeSinceEpoch();
 					}
@@ -262,14 +262,14 @@ namespace grb {
 						// give experiment output line
 						if( pid == 0 ) {
 							if( ret == grb::SUCCESS ) {
-								std::ios_base::fmtflags prev_cout_state( std::cout.flags() );
-								std::cout << "Outer iteration #" << out << " timings "
+								std::ios_base::fmtflags prev_cerr_state( std::cerr.flags() );
+								std::cerr << "Outer iteration #" << out << " timings "
 									<< "(io, preamble, useful, postamble, time since epoch): "
 									<< std::fixed
 									<< inner_times.io << ", " << inner_times.preamble << ", "
 									<< inner_times.useful << ", " << inner_times.postamble << ", ";
 									printTimeSinceEpoch( false );
-								std::cout.flags( prev_cout_state );
+								std::cerr.flags( prev_cerr_state );
 							} else {
 								std::cerr << "Error during cross-process collection of timing results: "
 									<< "\t" << grb::toString( ret ) << std::endl;

--- a/tests/smoke/hpcg.cpp
+++ b/tests/smoke/hpcg.cpp
@@ -96,7 +96,8 @@ using namespace grb;
 using namespace algorithms;
 
 static const char * const TEXT_HIGHLIGHT = "===> ";
-#define thcout ( std::cout << TEXT_HIGHLIGHT )
+// Note: Use stderr for all test output to keep stdout clean for HyperDAG data
+#define thcout ( std::cerr << TEXT_HIGHLIGHT )
 #define thcerr ( std::cerr << TEXT_HIGHLIGHT )
 
 
@@ -207,11 +208,11 @@ void print_norm(
 	(void) ret;
 #endif
 	assert( ret == SUCCESS );
-	std::cout << ">>> ";
+	std::cerr << ">>> ";
 	if( head != nullptr ) {
-		std::cout << head << ": ";
+		std::cerr << head << ": ";
 	}
-	std::cout << norm << std::endl;
+	std::cerr << norm << std::endl;
 }
 #endif
 
@@ -262,8 +263,8 @@ void grbProgram( const simulation_input &in, struct output &out ) {
 
 #ifdef HPCG_PRINT_SYSTEM
 	if( spmd<>::pid() == 0 ) {
-		print_vector( x, 50, "X" );
-		print_vector( b, 50, "B" );
+		print_vector( x, 50, "X", std::cerr );
+		print_vector( b, 50, "B", std::cerr );
 	}
 #endif
 
@@ -309,13 +310,13 @@ void grbProgram( const simulation_input &in, struct output &out ) {
 	if( spmd<>::pid() == 0 ) {
 		if( rc == SUCCESS ) {
 			if( in.evaluation_run ) {
-				std::cout << "Info: cold HPCG completed within " << out.performed_iterations
+				std::cerr << "Info: cold HPCG completed within " << out.performed_iterations
 					<< " iterations. Last computed residual is " << out.residual << ". "
 					<< "Time taken was " << out.times.useful << " ms. "
 					<< "Deduced inner repetitions parameter of " << out.test_repetitions << " "
 					<< "to take 1 second or more per inner benchmark." << std::endl;
 			} else {
-				std::cout << "Average time taken for each of " << out.test_repetitions
+				std::cerr << "Average time taken for each of " << out.test_repetitions
 					<< " HPCG calls (hot start): " << out.times.useful << std::endl;
 			}
 		} else {
@@ -415,7 +416,7 @@ int main( int argc, char ** argv ) {
 		const PinnedVector< double > &solution = *(out.pinnedVector);
 		thcout << "Size of x is " << solution.size() << std::endl;
 		if( solution.size() > 0 ) {
-			print_vector( solution, 30, "SOLUTION" );
+			print_vector( solution, 30, "SOLUTION", std::cerr );
 		} else {
 			thcerr << "ERROR: solution contains no values" << std::endl;
 		}
@@ -435,8 +436,9 @@ static void parse_arguments(
 	simulation_input &sim_in, size_t &outer_iterations, double &max_residual_norm,
 	int argc, char ** argv
 ) {
-	argument_parser parser;
-	parser.add_optional_argument( "--nx", sim_in.nx, PHYS_SYSTEM_SIZE_DEF, "physical system size along x" )
+	// Note: heap-allocate to avoid destructor crash with hyperdags backend
+	argument_parser* parser = new argument_parser();
+	parser->add_optional_argument( "--nx", sim_in.nx, PHYS_SYSTEM_SIZE_DEF, "physical system size along x" )
 		.add_optional_argument( "--ny", sim_in.ny, PHYS_SYSTEM_SIZE_DEF, "physical system size along y" )
 		.add_optional_argument( "--nz", sim_in.nz, PHYS_SYSTEM_SIZE_DEF, "physical system size along z" )
 		.add_optional_argument( "--max_coarse-levels", sim_in.max_coarsening_levels, DEF_COARSENING_LEVELS,
@@ -455,29 +457,29 @@ static void parse_arguments(
 			"repetitions)" )
 		.add_option( "--no-preconditioning", sim_in.no_preconditioning, false, "do not apply pre-conditioning via multi-grid V cycle" );
 
-	parser.parse( argc, argv );
+	parser->parse( argc, argv );
 
 	// check for valid values
 	size_t ssize = std::max( next_pow_2( sim_in.nx ), PHYS_SYSTEM_SIZE_MIN );
 	if( ssize != sim_in.nx ) {
-		std::cout << "Setting system size x to " << ssize << " instead of "
+		std::cerr << "Setting system size x to " << ssize << " instead of "
 			<< sim_in.nx << std::endl;
 		sim_in.nx = ssize;
 	}
 	ssize = std::max( next_pow_2( sim_in.ny ), PHYS_SYSTEM_SIZE_MIN );
 	if( ssize != sim_in.ny ) {
-		std::cout << "Setting system size y to " << ssize << " instead of "
+		std::cerr << "Setting system size y to " << ssize << " instead of "
 			<< sim_in.ny << std::endl;
 		sim_in.ny = ssize;
 	}
 	ssize = std::max( next_pow_2( sim_in.nz ), PHYS_SYSTEM_SIZE_MIN );
 	if( ssize != sim_in.nz ) {
-		std::cout << "Setting system size z to " << ssize << " instead of "
+		std::cerr << "Setting system size z to " << ssize << " instead of "
 			<< sim_in.nz << std::endl;
 		sim_in.nz = ssize;
 	}
 	if( sim_in.max_coarsening_levels > MAX_COARSENING_LEVELS ) {
-		std::cout << "Setting max coarsening level to " << MAX_COARSENING_LEVELS
+		std::cerr << "Setting max coarsening level to " << MAX_COARSENING_LEVELS
 			<< " instead of " << sim_in.max_coarsening_levels << std::endl;
 		sim_in.max_coarsening_levels = MAX_COARSENING_LEVELS;
 	}
@@ -487,7 +489,7 @@ static void parse_arguments(
 		std::exit( -1 );
 	}
 	if( sim_in.max_iterations == 0 ) {
-		std::cout << "Setting number of iterations to 1" << std::endl;
+		std::cerr << "Setting number of iterations to 1" << std::endl;
 		sim_in.max_iterations = 1;
 	}
 }

--- a/tests/smoke/smoketests.sh
+++ b/tests/smoke/smoketests.sh
@@ -135,15 +135,10 @@ for BACKEND in ${BACKENDS[@]}; do
 			fi
 			echo " "
 
-			if [ "${GITHUB_ACTIONS}" = true ] && [ "${BACKEND}" = "hyperdags" ]; then
-				echo "Test DISABLED; GitHub runner does not have enough memory for this test"
-			else
-				echo ">>>      [x]           [ ]       Tests HPCG on a small matrix"
-				echo "Functional test executable: ${TEST_BIN_DIR}/hpcg_${BACKEND}"
-				bash -c "$runner ${TEST_BIN_DIR}/hpcg_${BACKEND} 2>&1 | sed -e '1p' -e '/===/!d' > ${TEST_OUT_DIR}/hpcg_${BACKEND}_${P}_${T}.log"
-				grep 'Test OK' ${TEST_OUT_DIR}/hpcg_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
-			fi
-			echo " "
+			echo ">>>      [x]           [ ]       Tests HPCG on a small matrix"
+			echo "Functional test executable: ${TEST_BIN_DIR}/hpcg_${BACKEND}"
+			bash -c "$runner ${TEST_BIN_DIR}/hpcg_${BACKEND} 2>&1 | sed -e '1p' -e '/===/!d' > ${TEST_OUT_DIR}/hpcg_${BACKEND}_${P}_${T}.log"
+			grep 'Test OK' ${TEST_OUT_DIR}/hpcg_${BACKEND}_${P}_${T}.log || echo "Test FAILED"
 
 			echo ">>>      [x]           [ ]       Tests an automatically launching version of the simple pagerank"
 			echo "                                 algorithm for a small 10 x 10 problem. Verifies against known"

--- a/tests/utils/assertions.hpp
+++ b/tests/utils/assertions.hpp
@@ -51,17 +51,13 @@
 
 
 /**
- * The logger uses std::cout since it does not flush by default: in case of
- * parallel write text chunks from multiple processes are less likely to
- * overlap.
+ * The logger uses std::cerr to keep stdout clean for automated output
+ * (e.g., HyperDAG MatrixMarket files in hyperdags backend).
  *
- * \warning No overlap is not guaranteed though.
- *
- * \note In ALP tests, stderr is typically reserved for textual output checks
- *       while test messages meant for human consumption indeed are directed
- *       to stdout.
+ * \note For the hyperdags backend, stdout must be reserved for the HyperDAG
+ *       graph output in MatrixMarket format, so all test messages go to stderr.
  */
-#define __LOGGER_ERR ( std::cout )
+#define __LOGGER_ERR ( std::cerr )
 
 /**
  * Prints a line of text and flushes it.


### PR DESCRIPTION
The hyperdags backend writes its HyperDAG output to stdout during grb::finalize(), but the test framework was also printing to stdout, corrupting the MatrixMarket file.

Solution here is to redirected all test framework output from stdout to stderr.
The test now produces clean MatrixMarket HyperDAG on stdout (19,902 vertices, 36,153 hyperedges, 71,323 edges)

Which can be tested with 

```bash
make test_hpcg_hyperdags
tests/smoke/./hpcg_hyperdags --nx 4 --ny 4 --nz 4 --test-rep 1 --init-iter 1 --max_iter 50 > hyperdag_clean.mtx
```